### PR TITLE
Adiciona `amora.transaformations.parse_numbers`

### DIFF
--- a/amora/models.py
+++ b/amora/models.py
@@ -6,18 +6,18 @@ from importlib.util import spec_from_file_location, module_from_spec
 from inspect import getfile
 from pathlib import Path
 from typing import Iterable, List, Optional, Union, Dict, Any, Tuple, Type
-
 from amora.protocols import CompilableProtocol
 from amora.config import settings
 from sqlalchemy import MetaData, Table, select
+from sqlalchemy.sql import ColumnElement
 from sqlmodel import SQLModel, Field
-
 from sqlalchemy.orm import declared_attr
-
 from amora.types import Compilable
 from amora.utils import model_path_for_target_path, list_files
 
 select = select
+Column = ColumnElement
+Columns = Iterable[Column]
 Field = Field
 Model = Type["AmoraModel"]
 Models = Iterable[Model]

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -212,21 +212,12 @@ def is_numeric(column: Column) -> Compilable:
     Example SQL:
 
     ```sql
-    WITH `int_col_or_null` AS (
         SELECT
-            CAST({{ column }}, INT64) AS `col`
+            col
         FROM
-            {{ model }}
+            validation
         WHERE
-            {{ column }} IS NOT NULL
-    )
-
-    SELECT
-        col
-    FROM
-        int_col_or_null
-    WHERE
-        col IS NULL
+            REGEXP_CONTAINS(col, "[^0-9]")
     ```
 
     Example:
@@ -234,15 +225,8 @@ def is_numeric(column: Column) -> Compilable:
     ```python
     is_numeric(func.cast(Health.value, String).label('value_as_str'))
     ```
-
     """
-    int_col_or_null = (
-        select(func.cast(column, Integer).label("col"))
-        .where(column != None)
-        .cte("int_col_or_null")
-    )
-
-    return select(int_col_or_null.c.col).where(int_col_or_null.c.col == None)
+    return select(column).where(func.REGEXP_CONTAINS(column, "[^0-9]"))
 
 
 def is_non_negative(column: Column) -> Compilable:

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Callable
+from typing import Iterable, Optional, Callable, Union
 
 import pytest
 from sqlalchemy import (
@@ -7,14 +7,12 @@ from sqlalchemy import (
     Integer,
     func,
 )
-from sqlalchemy.orm import InstrumentedAttribute
 from sqlmodel.sql.expression import SelectOfScalar
-from amora.models import select, AmoraModel
+from amora.models import select, AmoraModel, Column, Columns
 from amora.types import Compilable
 from amora.providers.bigquery import run
 
-Column = InstrumentedAttribute
-Columns = Iterable[Column]
+
 Test = Callable[..., SelectOfScalar]
 
 

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -211,11 +211,11 @@ def is_numeric(column: Column) -> Compilable:
 
     ```sql
         SELECT
-            col
+            {{ column }}
         FROM
-            validation
+            {{ model }}
         WHERE
-            REGEXP_CONTAINS(col, "[^0-9]")
+            REGEXP_CONTAINS({{ column }}, "[^0-9]")
     ```
 
     Example:

--- a/amora/transformations.py
+++ b/amora/transformations.py
@@ -1,4 +1,5 @@
-from sqlalchemy import func, String, Column
+from sqlalchemy import func, String
+from amora.models import Column
 from sqlalchemy.sql.functions import Function
 
 

--- a/amora/transformations.py
+++ b/amora/transformations.py
@@ -18,3 +18,15 @@ def remove_leading_zeros(column: Column) -> Function:
      E.g: "00001000000" -> "1000000"
     """
     return func.regexp_replace(column, "^0+", "", type_=String)
+
+
+def parse_numbers(column: Column) -> Function:
+    """
+    Parses a string column as a number, returning NULL if value contains 0 numbers
+
+    E.g: "0031.752.270/0001-82" -> "31752270000182"
+         "IM_A_STRING_WITH_NO_NUMBERS" -> NULL
+    """
+    return func.nullif(
+        remove_leading_zeros(remove_non_numbers(column)), "", type_=String
+    )

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -27,6 +27,7 @@ def test_is_numeric_with_numeric_column_and_single_row():
     assert that(cte.c.numeric_column, is_numeric)
 
 
+@pytest.mark.xfail
 def test_is_numeric_with_non_numeric_values_on_column():
     bad_int = "23a4"
     cte = cte_from_rows(
@@ -37,8 +38,4 @@ def test_is_numeric_with_non_numeric_values_on_column():
         ]
     )
 
-    with pytest.raises(
-        BadRequest,
-        match=fr".*Bad int64 value: {bad_int}",
-    ):
-        assert that(cte.c.numeric_column, is_numeric)
+    assert that(cte.c.numeric_column, is_numeric)

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -27,7 +27,6 @@ def test_is_numeric_with_numeric_column_and_single_row():
     assert that(cte.c.numeric_column, is_numeric)
 
 
-@pytest.mark.xfail
 def test_is_numeric_with_non_numeric_values_on_column():
     bad_int = "23a4"
     cte = cte_from_rows(
@@ -38,4 +37,4 @@ def test_is_numeric_with_non_numeric_values_on_column():
         ]
     )
 
-    assert that(cte.c.numeric_column, is_numeric)
+    assert not that(cte.c.numeric_column, is_numeric, raise_on_fail=False)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,13 +1,18 @@
 from amora.models import select
 from amora.providers.bigquery import cte_from_rows, run
 from amora.tests.assertions import is_numeric, that
-from amora.transformations import remove_non_numbers, remove_leading_zeros
+from amora.transformations import (
+    remove_non_numbers,
+    remove_leading_zeros,
+    parse_numbers,
+)
 
 
 def test_remove_non_numbers():
     cte = cte_from_rows(
         [
             {"col": "a123"},
+            {"col": "aaaa"},
             {"col": "1a23"},
             {"col": "123a"},
             {"col": "123.456.789-45"},
@@ -25,6 +30,7 @@ def test_remove_non_numbers():
 
     assert [tuple(row) for row in run(statement).rows] == [
         ("a123", "123"),
+        ("aaaa", ""),
         ("1a23", "123"),
         ("123a", "123"),
         ("123.456.789-45", "12345678945"),
@@ -67,4 +73,33 @@ def test_remove_leading_zeros():
             "00009223372036854775807",
             "9223372036854775807",
         ),
+    ]
+
+
+def test_parse_numbers():
+    cte = cte_from_rows(
+        [
+            {"col": "aaa"},
+            {"col": "1a23"},
+            {"col": "123a"},
+            {"col": "123.456.789-45"},
+            {"col": "+55(21)123456-78945"},
+            {"col": "00031.752.270/0001-82"},
+        ]
+    )
+
+    statement = select(
+        cte.c.col,
+        parse_numbers(cte.c.col).label("col_with_numbers_only"),
+    )
+
+    assert that(statement.cte().c.col_with_numbers_only, is_numeric)
+
+    assert [tuple(row) for row in run(statement).rows] == [
+        ("aaa", None),
+        ("1a23", "123"),
+        ("123a", "123"),
+        ("123.456.789-45", "12345678945"),
+        ("+55(21)123456-78945", "552112345678945"),
+        ("00031.752.270/0001-82", "31752270000182"),
     ]


### PR DESCRIPTION
- ✨ Adiciona `amora.transaformations.parse_numbers`
- 🐛 Corrige `amora.tests.assertions.is_numeric`
- ✨ Refatora `amora.tests.assertions.that` para permitir que um teste retorne falso ao invés de levantar a excessão `pytest.Fail`