### PR TITLE
DTREX-414 e DTREX-415 :: estimated query/storage cost

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,9 @@ on:
 
 env:
   gcp_service_account: ${{ secrets.GCP_SA_KEY }}
+  AMORA_MODELS_PATH: "${{ github.workspace }}/examples/amora_project/models"
   AMORA_TARGET_SCHEMA: amora
+  AMORA_TARGET_PATH: "${{ github.workspace }}/examples/amora_project/target"
   AMORA_TARGET_PROJECT: amora-data-build-tool
 
 jobs:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,8 +3,10 @@ on: pull_request
 
 env:
   gcp_service_account: ${{ secrets.GCP_SA_KEY }}
-  AMORA_TARGET_SCHEMA: amora
+  AMORA_MODELS_PATH: "${{ github.workspace }}/tests/models"
+  AMORA_TARGET_PATH: "${{ github.workspace }}/tests/target"
   AMORA_TARGET_PROJECT: amora-data-build-tool
+  AMORA_TARGET_SCHEMA: amora
 
 jobs:
   qa:

--- a/amora/cli.py
+++ b/amora/cli.py
@@ -196,7 +196,7 @@ def models_list(
             )
 
         @property
-        def estimated_query_cost_in_usd(self) -> str:
+        def estimated_query_cost_in_usd(self) -> Optional[str]:
             if self.dry_run_result:
                 cost = estimated_query_cost_in_usd(
                     self.dry_run_result.total_bytes
@@ -205,7 +205,7 @@ def models_list(
             return None
 
         @property
-        def estimated_storage_cost_in_usd(self) -> str:
+        def estimated_storage_cost_in_usd(self) -> Optional[str]:
             if self.dry_run_result:
                 cost = estimated_storage_cost_in_usd(
                     self.dry_run_result.total_bytes

--- a/amora/config.py
+++ b/amora/config.py
@@ -22,7 +22,9 @@ class Settings(BaseSettings):
     CLI_CONSOLE_MAX_WIDTH: int = 160
     CLI_MATERIALIZATION_DAG_FIGURE_SIZE: Tuple[_Width, _Height] = (32, 32)
 
+    # https://cloud.google.com/bigquery/pricing#analysis_pricing_models
     GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD: float = 5.0
+    # https://cloud.google.com/bigquery/pricing#storage
     GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD: float = 0.020
 
     LOCAL_ENGINE_ECHO: bool = False

--- a/amora/config.py
+++ b/amora/config.py
@@ -1,4 +1,7 @@
+import os
+from uuid import uuid4
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Tuple
 
 from pydantic import BaseSettings
@@ -13,8 +16,12 @@ _Height = float
 class Settings(BaseSettings):
     TARGET_PROJECT: str
     TARGET_SCHEMA: str
-    TARGET_PATH: Path = AMORA_MODULE_PATH.joinpath("target")
-    MODELS_PATH: Path = ROOT_PATH.joinpath("dbt/models")
+    TARGET_PATH: Path
+    MODELS_PATH: Path
+
+    SQLITE_FILE_PATH: Path = Path(
+        NamedTemporaryFile(suffix="amora-sqlite.db", delete=False).name
+    )
 
     CLI_CONSOLE_MAX_WIDTH: int = 160
     CLI_MATERIALIZATION_DAG_FIGURE_SIZE: Tuple[_Width, _Height] = (32, 32)
@@ -23,6 +30,10 @@ class Settings(BaseSettings):
     GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD: float = 0.020
 
     MONEY_DECIMAL_PLACES: int = 4
+
+    TEST_RUN_ID: str = (
+        os.getenv("PYTEST_XDIST_TESTRUNUID") or f"amora-{uuid4().hex}"
+    )
 
     class Config:
         env_prefix = "AMORA_"

--- a/amora/config.py
+++ b/amora/config.py
@@ -19,15 +19,16 @@ class Settings(BaseSettings):
     TARGET_PATH: Path
     MODELS_PATH: Path
 
-    SQLITE_FILE_PATH: Path = Path(
-        NamedTemporaryFile(suffix="amora-sqlite.db", delete=False).name
-    )
-
     CLI_CONSOLE_MAX_WIDTH: int = 160
     CLI_MATERIALIZATION_DAG_FIGURE_SIZE: Tuple[_Width, _Height] = (32, 32)
 
     GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD: float = 5.0
     GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD: float = 0.020
+
+    LOCAL_ENGINE_ECHO: bool = False
+    LOCAL_ENGINE_SQLITE_FILE_PATH: Path = Path(
+        NamedTemporaryFile(suffix="amora-sqlite.db", delete=False).name
+    )
 
     MONEY_DECIMAL_PLACES: int = 4
 

--- a/amora/config.py
+++ b/amora/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     CLI_MATERIALIZATION_DAG_FIGURE_SIZE: Tuple[_Width, _Height] = (32, 32)
 
     GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD: float = 5.0
+    GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD: float = 0.020
+
+    MONEY_DECIMAL_PLACES: int = 4
 
     class Config:
         env_prefix = "AMORA_"

--- a/amora/config.py
+++ b/amora/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     CLI_CONSOLE_MAX_WIDTH: int = 160
     CLI_MATERIALIZATION_DAG_FIGURE_SIZE: Tuple[_Width, _Height] = (32, 32)
 
+    GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD: float = 5.0
+
     class Config:
         env_prefix = "AMORA_"
 

--- a/amora/contracts.py
+++ b/amora/contracts.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, List
+
+
+@dataclass
+class TimingInfo:
+    name: str
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
+@dataclass
+class BaseResult:
+    """
+    Base dataclass for query execution result data
+    """
+
+    total_bytes: int
+    query: str
+    job_id: str
+    referenced_tables: List[str]
+    user_email: str
+    execution_time_in_ms: int

--- a/amora/contracts.py
+++ b/amora/contracts.py
@@ -17,8 +17,7 @@ class BaseResult:
     """
 
     total_bytes: int
-    query: str
-    job_id: str
+    query: Optional[str]
+    job_id: Optional[str]
     referenced_tables: List[str]
-    user_email: str
-    execution_time_in_ms: int
+    user_email: Optional[str]

--- a/amora/models.py
+++ b/amora/models.py
@@ -10,7 +10,7 @@ from typing import Iterable, List, Optional, Union, Dict, Any, Tuple, Type
 from amora.protocols import CompilableProtocol
 from amora.config import settings
 from sqlalchemy import MetaData, Table, select
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, create_engine, Session
 
 from sqlalchemy.orm import declared_attr
 
@@ -20,7 +20,10 @@ from amora.utils import model_path_for_target_path, list_files
 select = select
 Field = Field
 Model = Type["AmoraModel"]
+MetaData = MetaData
 Models = Iterable[Model]
+Session = Session
+create_engine = create_engine
 
 
 @dataclass

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -56,7 +56,7 @@ class DryRunResult:
 
     @property
     def estimated_cost(self):
-        raise NotImplementedError
+        return estimated_query_cost_in_usd(self.total_bytes)
 
 
 @dataclass
@@ -69,7 +69,7 @@ class RunResult:
 
     @property
     def estimated_cost(self):
-        raise NotImplementedError
+        return estimated_query_cost_in_usd(self.total_bytes)
 
 
 _client = None
@@ -252,4 +252,27 @@ def estimated_query_cost_in_usd(total_bytes: int) -> float:
     return (
         total_terabytes
         * settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD
+    )
+
+
+def estimated_storage_cost_in_usd(total_bytes: int) -> float:
+    """
+    Storage pricing is the cost to store data that you load into BigQuery.
+    `Active storage` includes any table or table partition that has been modified in the last 90 days.
+
+    - This function doesn't take into consideration that the first 10 GB of storage per month is free.
+    - By default, the estimation is based on BigQuery's `Active Storage` cost per GB, which may change over time and
+    may vary according to regions and your personal contract with GCP.
+
+    You may set `AMORA_GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD` to the appropriate value for your use case.
+
+    More on: https://cloud.google.com/bigquery/pricing#storage
+
+    :param total_bytes: Total bytes stored into the table
+    :return: The estimated cost in USD, based on `Active storage` price
+    """
+    total_gigabytes = total_bytes / 1024 ** 3
+    return (
+        total_gigabytes
+        * settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD
     )

--- a/amora/storage.py
+++ b/amora/storage.py
@@ -2,6 +2,7 @@ from amora.config import settings
 from amora.models import create_engine, MetaData
 
 local_engine = create_engine(
-    f"sqlite:///{settings.SQLITE_FILE_PATH}", echo=True
+    f"sqlite:///{settings.LOCAL_ENGINE_SQLITE_FILE_PATH}",
+    echo=settings.LOCAL_ENGINE_ECHO,
 )
 local_metadata = MetaData(schema=None)

--- a/amora/storage.py
+++ b/amora/storage.py
@@ -1,0 +1,6 @@
+from amora.config import settings
+from amora.models import create_engine
+
+local_storage = create_engine(
+    f"sqlite:///{settings.SQLITE_FILE_PATH}", echo=True
+)

--- a/amora/storage.py
+++ b/amora/storage.py
@@ -1,6 +1,7 @@
 from amora.config import settings
-from amora.models import create_engine
+from amora.models import create_engine, MetaData
 
-local_storage = create_engine(
+local_engine = create_engine(
     f"sqlite:///{settings.SQLITE_FILE_PATH}", echo=True
 )
+local_metadata = MetaData(schema=None)

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -14,7 +14,7 @@ from sqlmodel.sql.expression import SelectOfScalar
 
 from amora.config import settings
 from amora.models import select, AmoraModel, Session
-from amora.storage import local_storage
+from amora.storage import local_engine
 from amora.tests.audit import AuditLog
 from amora.types import Compilable
 from amora.providers.bigquery import run, RunResult, estimated_query_cost_in_usd
@@ -26,7 +26,7 @@ Test = Callable[..., SelectOfScalar]
 
 
 def _log_result(run_result: RunResult) -> AuditLog:
-    with Session(local_storage) as session:
+    with Session(local_engine) as session:
         log = AuditLog(
             bytes_billed=run_result.total_bytes,
             estimated_cost_in_usd=estimated_query_cost_in_usd(

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Optional, Callable
+import os
+from typing import Iterable, Optional, Callable, Dict, List
 
 import pytest
 from sqlalchemy import (
@@ -11,15 +12,19 @@ from sqlalchemy.orm import InstrumentedAttribute
 from sqlmodel.sql.expression import SelectOfScalar
 from amora.models import select, AmoraModel
 from amora.types import Compilable
-from amora.providers.bigquery import run
+from amora.providers.bigquery import run, RunResult
+from collections import defaultdict
 
 Column = InstrumentedAttribute
 Columns = Iterable[Column]
 Test = Callable[..., SelectOfScalar]
 
+_REGISTRY: Dict[str, List[RunResult]] = defaultdict(list)
+
 
 def _test(statement: Compilable) -> bool:
     run_result = run(statement)
+    _REGISTRY[os.getenv("PYTEST_CURRENT_TEST")].append(run_result)
 
     if run_result.rows.total_rows == 0:
         return True

--- a/amora/tests/audit.py
+++ b/amora/tests/audit.py
@@ -72,7 +72,7 @@ class AuditLog(AmoraModel, table=True):
     def get_all(cls, test_run_id: str) -> Iterable["AuditLog"]:
         with Session(local_engine) as session:
             statement = select(cls).where(cls.test_run_id == test_run_id)
-            return (log for (log, *_) in session.exec(statement).all())
+            return (log for (log, *_) in session.exec(statement).all())  # type: ignore
 
 
 class AuditReport(AmoraModel, table=True):

--- a/amora/tests/audit.py
+++ b/amora/tests/audit.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Iterable
 
 from sqlalchemy import func
 
@@ -11,6 +11,7 @@ from amora.models import (
     select,
     ModelConfig,
     MaterializationTypes,
+    Session,
 )
 from amora.storage import local_engine, local_metadata
 from amora.config import settings
@@ -66,6 +67,12 @@ class AuditLog(AmoraModel, table=True):
         description="The name of the `pytest-xdist` worker. E.g.: gw2",
         default=os.getenv("PYTEST_XDIST_WORKER"),
     )
+
+    @classmethod
+    def get_all(cls, test_run_id: str) -> Iterable["AuditLog"]:
+        with Session(local_engine) as session:
+            statement = select(cls).where(cls.test_run_id == test_run_id)
+            return (log for (log, *_) in session.exec(statement).all())
 
 
 class AuditReport(AmoraModel, table=True):

--- a/amora/tests/audit.py
+++ b/amora/tests/audit.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Optional
+
+from amora.models import AmoraModel, Field, MetaData
+from amora.storage import local_storage
+from amora.config import settings
+from amora.version import VERSION
+
+
+class AuditLog(AmoraModel, table=True):
+    """
+    Stores test log data
+    """
+
+    metadata = MetaData(schema=None)
+
+    test_run_id: str = Field(
+        primary_key=True,
+        description="Unique id of the test run",
+        nullable=False,
+    )
+    test_node_id: str = Field(
+        primary_key=True,
+        description="pytest full node id of the item",
+        nullable=False,
+    )
+    bytes_billed: int = Field(
+        description="Total billable scanned bytes during query executions"
+    )
+    estimated_cost_in_usd: float = Field(
+        description="Estimated cost of query executions"
+    )
+    query: str = Field(description="SQL query executed for data assertion")
+    user_email: Optional[str] = Field(
+        description="GCP user email that performed the query", nullable=True
+    )
+    execution_time_in_ms: int = Field(
+        description="Query execution time in miliseconds"
+    )
+    inserted_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="UTC Datetime of the insert",
+    )
+    referenced_tables: str = Field(
+        description="JSON encoded referenced tables on the query", nullable=True
+    )
+    settings: str = Field(
+        description="JSON encoded current`amora.config.settings`",
+        default=settings.json(),
+    )
+    amora_version: str = Field(
+        description="Current version of the amora package", default=VERSION
+    )
+
+
+AuditLog.__table__.create(bind=local_storage, checkfirst=True)

--- a/amora/tests/audit.py
+++ b/amora/tests/audit.py
@@ -21,7 +21,7 @@ from amora.version import VERSION
 
 class AuditLog(AmoraModel, table=True):
     __model_config__ = ModelConfig(
-        materialized=MaterializationTypes.view,
+        materialized=MaterializationTypes.table,
         description="Stores test log data",
     )
     metadata = local_metadata

--- a/amora/tests/pytest_plugin.py
+++ b/amora/tests/pytest_plugin.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 from _pytest.fixtures import SubRequest
+from amora.tests.assertions import _REGISTRY
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -23,7 +24,12 @@ A amora adoça mais na boca de quem namora.
 
 
 def teardown_test_environment():
-    print("todo: Print table with total bytes billed, query time, etc")
+    for test, results in _REGISTRY.items():
+        total_bytes = sum(r.total_bytes for r in results)
+        total_cost = sum(r.estimated_cost for r in results)
+        print(
+            f"🤑 {test} :: Total bytes: {total_bytes} :: Estimated cost: ${total_cost}"
+        )
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/amora/tests/pytest_plugin.py
+++ b/amora/tests/pytest_plugin.py
@@ -42,4 +42,4 @@ def pytest_sessionfinish(
         )
 
     console = Console(width=settings.CLI_CONSOLE_MAX_WIDTH)
-    console.print(table)
+    console.print(table, new_line_start=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dbt-bigquery = "^1.0.0"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.poetry.plugins."pytest11"]
+amora = "amora.tests.pytest_plugin"
+
 [tool.poetry.scripts]
 amora = "amora.cli:main"
 

--- a/tests/providers/test_bigquery.py
+++ b/tests/providers/test_bigquery.py
@@ -3,7 +3,11 @@ from sqlalchemy.exc import CompileError
 from sqlalchemy.sql.selectable import CTE
 
 from amora.compilation import compile_statement
-from amora.providers.bigquery import cte_from_rows, estimated_query_cost_in_usd
+from amora.providers.bigquery import (
+    cte_from_rows,
+    estimated_query_cost_in_usd,
+    estimated_storage_cost_in_usd,
+)
 
 
 def test_cte_from_rows_with_single_row():
@@ -31,6 +35,7 @@ def test_cte_from_rows_with_distinguished_schema_rows():
 
 
 ONE_TERABYTE = 1 * 1024 ** 4
+ONE_GIGABYTE = 1 * 1024 ** 3
 
 
 @pytest.mark.parametrize(
@@ -44,3 +49,16 @@ ONE_TERABYTE = 1 * 1024 ** 4
 )
 def test_estimated_query_cost_in_usd(total_bytes: int, expected_cost: float):
     assert estimated_query_cost_in_usd(total_bytes) == expected_cost
+
+
+@pytest.mark.parametrize(
+    "total_bytes, expected_cost",
+    [
+        (0, 0),
+        (ONE_GIGABYTE, 0.020),
+        (ONE_GIGABYTE * 10, 0.200),
+        (ONE_GIGABYTE / 2, 0.010),
+    ],
+)
+def test_estimated_storage_cost_in_usd(total_bytes: int, expected_cost: float):
+    assert estimated_storage_cost_in_usd(total_bytes) == expected_cost

--- a/tests/providers/test_bigquery.py
+++ b/tests/providers/test_bigquery.py
@@ -8,6 +8,7 @@ from amora.providers.bigquery import (
     estimated_query_cost_in_usd,
     estimated_storage_cost_in_usd,
 )
+from amora.config import settings
 
 
 def test_cte_from_rows_with_single_row():
@@ -42,9 +43,18 @@ ONE_GIGABYTE = 1 * 1024 ** 3
     "total_bytes, expected_cost",
     [
         (0, 0),
-        (ONE_TERABYTE, 5.0),
-        (ONE_TERABYTE * 10, 50.0),
-        (ONE_TERABYTE / 2, 2.5),
+        (
+            ONE_TERABYTE,
+            settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD,
+        ),
+        (
+            ONE_TERABYTE * 10,
+            settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD * 10,
+        ),
+        (
+            ONE_TERABYTE / 2,
+            settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD / 2,
+        ),
     ],
 )
 def test_estimated_query_cost_in_usd(total_bytes: int, expected_cost: float):
@@ -55,9 +65,18 @@ def test_estimated_query_cost_in_usd(total_bytes: int, expected_cost: float):
     "total_bytes, expected_cost",
     [
         (0, 0),
-        (ONE_GIGABYTE, 0.020),
-        (ONE_GIGABYTE * 10, 0.200),
-        (ONE_GIGABYTE / 2, 0.010),
+        (
+            ONE_GIGABYTE,
+            settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD,
+        ),
+        (
+            ONE_GIGABYTE * 10,
+            settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD * 10,
+        ),
+        (
+            ONE_GIGABYTE / 2,
+            settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD / 2,
+        ),
     ],
 )
 def test_estimated_storage_cost_in_usd(total_bytes: int, expected_cost: float):


### PR DESCRIPTION
## Materialização

O processo de materialização gera 2 tipos de custos: custo de escanear os dados [1] a serem transformados e o custo de armazenar [2] esses dados para modelos materializados como `MaterializationTypes.table`. No BQ os custos hoje são definidos da seguinte forma: 

1-  Custo de query é definido hoje por $5 por TB
![Screen Shot 2022-01-18 at 10 03 20](https://user-images.githubusercontent.com/6271498/149942430-3313c41d-15c6-4eb1-ada2-e77d096ea314.png)

2- Custo de armazenamento é definido por $0.020 por GB/mês

![Screen Shot 2022-01-18 at 10 04 03](https://user-images.githubusercontent.com/6271498/149942513-c9c90b52-df80-427c-8ce0-c25d9279a628.png)


## Relatório de custos ao final da execução dos testes.

Cada data assertion é uma query sql. Cada query SQL, se executada em dados persistidos no BQ, incorre em billable bytes. No amora, cada query executada com `amora.providers.bigquery.run` resulta em um `RunResult` ou em um `DryRunResult`. Em ambos os casos, temos o total de bytes processados pelo BQ. A partir disso, podemos calcular quanto o BQ nos cobra, usando a fórmula de billing de [5 Bidens por Tb](https://cloud.google.com/bigquery/pricing#analysis_pricing_models). A ideia aqui é guardar o resultado de que cada query executada nos testes da forma `test_node_id -> [run_result1, run_result2], ...`

Como paralelizamos os testes usando `pytest-xdist`, cada teste pode executar em um processo diferente. Concordamos em usar SQLite para armazenar os resultados desses testes e outras metadados disponíveis. Ao final dos testes, podemos consultar a base para imprimir o relatório e, opcionalmente, enviar esses dados para o BQ. Cada execução de testes possui um `PYTEST_XDIST_TESTRUNUID`, acessível por envvar,  que identifica de forma única uma execução de testes.

### AuditLog
Tabela definida como um AmoraModel, persistida em um SQLite, com o seguinte schema:

```sql
create table audit_log
(
    test_run_id           VARCHAR not null,
    test_node_id          VARCHAR not null,
    bytes_billed          INTEGER not null,
    estimated_cost_in_usd FLOAT   not null,
    query                 VARCHAR not null,
    user_email            VARCHAR,
    execution_time_in_ms  INTEGER not null,
    inserted_at           DATETIME,
    referenced_tables     VARCHAR,
    settings              VARCHAR,
    amora_version         VARCHAR,
    xdist_worker_id       VARCHAR,
    primary key (test_run_id, test_node_id)
);
```



---
# Changelog

- ✨ Adiciona colunas "Estimated query cost" e "Estimated storage cost" a `amora models list --with-total-bytes`
![image](https://user-images.githubusercontent.com/6271498/149943578-6d1e2735-08ad-4d6d-bc99-271c7f6e616a.png)
- ✨ Adiciona possibilidade de alterar valores base de calculo de billing através das variáveis de ambiente `AMORA_GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD` e `AMORA_GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD`. Também é possível alterar a quantidade de casas decimais exibidas em relatórios a partir da variável `AMORA_MONEY_DECIMAL_PLACES`
- ✨ Adiciona relatório de custos ao final da execução de testes
- ✨ Adiciona modelos amora `amora.tests.audit.AuditLog`, persistido em um SQLite local