### PR TITLE
Fix: DTREX-560 :: dry run

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v0"
 
       - name: 🎨 Black - Python format check
-        run: black -v --line-length 80 --check amora tests
+        run: black -v --check amora tests
 
       - name: 🧪 pytest
         run: py.test --cov=amora --cov-report=term-missing --cov-report=xml ./tests

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v0"
 
       - name: 🎨 Black - Python format check
-        run: black -v --line-length 80 --check amora tests
+        run: black -v --check amora tests
 
       - name: 🧪 pytest
         run: py.test --cov=amora --cov-report=term-missing --cov-report=xml ./tests

--- a/amora/cli.py
+++ b/amora/cli.py
@@ -66,9 +66,7 @@ def compile(
             continue
 
         target_file_path = model.target_path(model_file_path)
-        typer.echo(
-            f"🏗 Compiling model `{model_file_path}` -> `{target_file_path}`"
-        )
+        typer.echo(f"🏗 Compiling model `{model_file_path}` -> `{target_file_path}`")
 
         content = compile_statement(source_sql_statement)
         target_file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -106,9 +104,7 @@ def materialize(
             typer.echo(f"⚠️  Skipping `{model}`")
             continue
         else:
-            table = materialization.materialize(
-                sql=task.sql_stmt, model=task.model
-            )
+            table = materialization.materialize(sql=task.sql_stmt, model=task.model)
             if table is None:
                 continue
 
@@ -189,27 +185,20 @@ def models_list(
         @property
         def depends_on(self) -> List[str]:
             return sorted(
-                [
-                    dependency.__name__
-                    for dependency in self.model.dependencies()
-                ]
+                [dependency.__name__ for dependency in self.model.dependencies()]
             )
 
         @property
         def estimated_query_cost_in_usd(self) -> Optional[str]:
             if self.dry_run_result:
-                cost = estimated_query_cost_in_usd(
-                    self.dry_run_result.total_bytes
-                )
+                cost = estimated_query_cost_in_usd(self.dry_run_result.total_bytes)
                 return f"{cost:.{settings.MONEY_DECIMAL_PLACES}f}"
             return None
 
         @property
         def estimated_storage_cost_in_usd(self) -> Optional[str]:
             if self.dry_run_result:
-                cost = estimated_storage_cost_in_usd(
-                    self.dry_run_result.total_bytes
-                )
+                cost = estimated_storage_cost_in_usd(self.dry_run_result.total_bytes)
                 return f"{cost:.{settings.MONEY_DECIMAL_PLACES}f}"
             return None
 
@@ -271,9 +260,7 @@ def models_list(
                     "\n".join(result.referenced_tables) or placeholder,
                     overflow="fold",
                 ),
-                Text(
-                    "\n".join(result.depends_on) or placeholder, overflow="fold"
-                ),
+                Text("\n".join(result.depends_on) or placeholder, overflow="fold"),
                 "🟢" if result.has_source else "🔴",
                 result.materialization_type or placeholder,
             )
@@ -312,9 +299,7 @@ def models_import(
     ```
     """
 
-    env = Environment(
-        loader=PackageLoader("amora"), autoescape=select_autoescape()
-    )
+    env = Environment(loader=PackageLoader("amora"), autoescape=select_autoescape())
     template = env.get_template("new-model.py.jinja2")
 
     project, dataset, table = table_reference.split(".")

--- a/amora/compilation.py
+++ b/amora/compilation.py
@@ -23,9 +23,7 @@ dialect.statement_compiler = AmoraBigQueryCompiler
 
 def compile_statement(statement: Compilable) -> str:
     raw_sql = str(
-        statement.compile(
-            dialect=dialect, compile_kwargs={"literal_binds": True}
-        )
+        statement.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     )
     formatted_sql = sqlparse.format(raw_sql, reindent=True, indent_columns=True)
     return formatted_sql

--- a/amora/config.py
+++ b/amora/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from uuid import uuid4
 from pathlib import Path
@@ -31,12 +32,11 @@ class Settings(BaseSettings):
     LOCAL_ENGINE_SQLITE_FILE_PATH: Path = Path(
         NamedTemporaryFile(suffix="amora-sqlite.db", delete=False).name
     )
+    LOGGER_LOG_LEVEL: int = logging.DEBUG
 
     MONEY_DECIMAL_PLACES: int = 4
 
-    TEST_RUN_ID: str = (
-        os.getenv("PYTEST_XDIST_TESTRUNUID") or f"amora-{uuid4().hex}"
-    )
+    TEST_RUN_ID: str = os.getenv("PYTEST_XDIST_TESTRUNUID") or f"amora-{uuid4().hex}"
 
     class Config:
         env_prefix = "AMORA_"

--- a/amora/logger.py
+++ b/amora/logger.py
@@ -1,0 +1,8 @@
+import logging
+import sys
+
+from amora.config import settings
+
+logger = logging.getLogger("amora")
+logger.setLevel(settings.LOGGER_LOG_LEVEL)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))

--- a/amora/models.py
+++ b/amora/models.py
@@ -198,7 +198,7 @@ def list_models(
         try:
             yield amora_model_for_path(model_file_path), model_file_path
         except ValueError:
-            logger.debug(
+            logger.warning(
                 "Unable to load amora model for path",
                 extra={"model_file_path": model_file_path},
             )

--- a/amora/models.py
+++ b/amora/models.py
@@ -6,6 +6,8 @@ from importlib.util import spec_from_file_location, module_from_spec
 from inspect import getfile
 from pathlib import Path
 from typing import Iterable, List, Optional, Union, Dict, Any, Tuple, Type
+
+from amora.logger import logger
 from amora.protocols import CompilableProtocol
 from amora.config import settings
 from sqlalchemy import MetaData, Table, select
@@ -70,9 +72,7 @@ def is_py_model(obj) -> bool:
     return hasattr(obj, "source") and hasattr(obj, "output")
 
 
-metadata = MetaData(
-    schema=f"{settings.TARGET_PROJECT}.{settings.TARGET_SCHEMA}"
-)
+metadata = MetaData(schema=f"{settings.TARGET_PROJECT}.{settings.TARGET_SCHEMA}")
 
 
 class AmoraModel(SQLModel):
@@ -163,9 +163,7 @@ def amora_model_for_path(path: Path) -> Model:
     try:
         spec.loader.exec_module(module)  # type: ignore
     except ImportError as e:
-        raise ValueError(
-            f"Invalid path `{path}`. Unable to load module."
-        ) from e
+        raise ValueError(f"Invalid path `{path}`. Unable to load module.") from e
     is_amora_model = (
         lambda x: isinstance(x, CompilableProtocol)
         and inspect.isclass(x)
@@ -200,4 +198,8 @@ def list_models(
         try:
             yield amora_model_for_path(model_file_path), model_file_path
         except ValueError:
+            logger.debug(
+                "Unable to load amora model for path",
+                extra={"model_file_path": model_file_path},
+            )
             continue

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -171,7 +171,7 @@ def dry_run(model: Model) -> Optional[DryRunResult]:
                 job_id=None,
                 model=model,
                 query=None,
-                referenced_tables=[".".join(table.to_api_repr().values())],
+                referenced_tables=[str(table.reference)],
                 schema=table.schema,
                 total_bytes=table.num_bytes,
                 user_email=None,
@@ -262,10 +262,7 @@ def estimated_query_cost_in_usd(total_bytes: int) -> float:
     :return: The estimated cost in USD, based on `On-demand` price
     """
     total_terabytes = total_bytes / 1024 ** 4
-    return (
-        total_terabytes
-        * settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD
-    )
+    return total_terabytes * settings.GCP_BIGQUERY_ON_DEMAND_COST_PER_TERABYTE_IN_USD
 
 
 def estimated_storage_cost_in_usd(total_bytes: int) -> float:
@@ -286,6 +283,5 @@ def estimated_storage_cost_in_usd(total_bytes: int) -> float:
     """
     total_gigabytes = total_bytes / 1024 ** 3
     return (
-        total_gigabytes
-        * settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD
+        total_gigabytes * settings.GCP_BIGQUERY_ACTIVE_STORAGE_COST_PER_GIGABYTE_IN_USD
     )

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -26,9 +26,7 @@ def _log_result(run_result: RunResult) -> AuditLog:
     with Session(local_engine) as session:
         log = AuditLog(
             bytes_billed=run_result.total_bytes,
-            estimated_cost_in_usd=estimated_query_cost_in_usd(
-                run_result.total_bytes
-            ),
+            estimated_cost_in_usd=estimated_query_cost_in_usd(run_result.total_bytes),
             execution_time_in_ms=run_result.execution_time_in_ms,
             query=run_result.query,
             referenced_tables=json.dumps(run_result.referenced_tables),
@@ -85,9 +83,7 @@ def that(
     :param test_kwargs: Keyword arguments passed to the `test` function
 
     """
-    return _test(
-        statement=test(column, **test_kwargs), raise_on_fail=raise_on_fail
-    )
+    return _test(statement=test(column, **test_kwargs), raise_on_fail=raise_on_fail)
 
 
 def is_not_null(column: Column) -> Compilable:
@@ -332,9 +328,7 @@ def expression_is_true(expression, condition=None) -> bool:
 
     """
     return _test(
-        statement=select(["*"])
-        .where(condition or and_(True))
-        .where(~expression)
+        statement=select(["*"]).where(condition or and_(True)).where(~expression)
     )
 
 
@@ -388,9 +382,7 @@ def has_at_least_one_not_null_value(column: Column) -> Compilable:
     has_at_least_one_not_null_value(Health.value)
     ```
     """
-    return select(func.count(column, type_=Integer)).having(
-        func.count(column) == 0
-    )
+    return select(func.count(column, type_=Integer)).having(func.count(column) == 0)
 
 
 def are_unique_together(columns: Iterable[Column]) -> Compilable:
@@ -406,6 +398,4 @@ def are_unique_together(columns: Iterable[Column]) -> Compilable:
     ```
 
     """
-    return (
-        select(columns).group_by(*columns).having(func.count(type_=Integer) > 1)
-    )
+    return select(columns).group_by(*columns).having(func.count(type_=Integer) > 1)

--- a/amora/tests/audit.py
+++ b/amora/tests/audit.py
@@ -46,9 +46,7 @@ class AuditLog(AmoraModel, table=True):
     user_email: Optional[str] = Field(
         description="GCP user email that performed the query", nullable=True
     )
-    execution_time_in_ms: int = Field(
-        description="Query execution time in miliseconds"
-    )
+    execution_time_in_ms: int = Field(description="Query execution time in miliseconds")
     inserted_at: datetime = Field(
         default_factory=datetime.utcnow,
         description="UTC Datetime of the insert",
@@ -103,14 +101,10 @@ class AuditReport(AmoraModel, table=True):
             AuditLog.test_run_id,
             AuditLog.amora_version,
             AuditLog.user_email,
-            func.sum(AuditLog.execution_time_in_ms).label(
-                cls.total_query_time.key
-            ),
+            func.sum(AuditLog.execution_time_in_ms).label(cls.total_query_time.key),
             func.sum(AuditLog.estimated_cost_in_usd).label(cls.total_cost.key),
             func.sum(AuditLog.bytes_billed).label(cls.total_bytes_billed.key),
-        ).group_by(
-            AuditLog.test_run_id, AuditLog.amora_version, AuditLog.user_email
-        )
+        ).group_by(AuditLog.test_run_id, AuditLog.amora_version, AuditLog.user_email)
 
 
 AuditLog.__table__.create(bind=local_engine, checkfirst=True)

--- a/amora/tests/pytest_plugin.py
+++ b/amora/tests/pytest_plugin.py
@@ -19,9 +19,7 @@ A amora adoça mais na boca de quem namora.
     )
 
 
-def pytest_sessionfinish(
-    session: Session, exitstatus: Union[int, ExitCode]
-) -> None:
+def pytest_sessionfinish(session: Session, exitstatus: Union[int, ExitCode]) -> None:
     log_rows = AuditLog.get_all(test_run_id=settings.TEST_RUN_ID)
 
     table = Table(

--- a/amora/utils.py
+++ b/amora/utils.py
@@ -12,9 +12,7 @@ def list_files(path: Union[str, Path], suffix: str) -> Iterable[Path]:
 def model_path_for_target_path(path: Path) -> Path:
     return Path(
         str(path)
-        .replace(
-            settings.TARGET_PATH.as_posix(), settings.MODELS_PATH.as_posix()
-        )
+        .replace(settings.TARGET_PATH.as_posix(), settings.MODELS_PATH.as_posix())
         .replace(".sql", ".py"),
     )
 
@@ -22,9 +20,7 @@ def model_path_for_target_path(path: Path) -> Path:
 def target_path_for_model_path(path: Path) -> Path:
     return Path(
         str(path)
-        .replace(
-            settings.MODELS_PATH.as_posix(), settings.TARGET_PATH.as_posix()
-        )
+        .replace(settings.MODELS_PATH.as_posix(), settings.TARGET_PATH.as_posix())
         .replace(".py", ".sql")
     )
 

--- a/examples/amora_project/models/heart_rate_over_100.py
+++ b/examples/amora_project/models/heart_rate_over_100.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Optional
+
+from amora.models import (
+    AmoraModel,
+    select,
+    MaterializationTypes,
+    ModelConfig,
+    Field,
+)
+from amora.types import Compilable
+from examples.amora_project.models.heart_rate import HeartRate
+
+
+class HeartRateOver100(AmoraModel, table=True):
+    __tablename__ = "heart_rate_over_100"
+    __depends_on__ = [HeartRate]
+    __model_config__ = ModelConfig(
+        materialized=MaterializationTypes.view,
+        labels={"freshness": "daily"},
+    )
+
+    unit: str
+    value: float
+    creationDate: datetime
+    id: int = Field(primary_key=True)
+
+    @classmethod
+    def source(cls) -> Optional[Compilable]:
+        return select(
+            [HeartRate.id, HeartRate.unit, HeartRate.creationDate, HeartRate.value]
+        ).where(HeartRate.value >= 100)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amora"
-version = "0.1.7"
+version = "0.1.8"
 description = "Amora Data Build Tool"
 authors = ["diogommartins <diogo.martins@stone.com.br>"]
 license = "MIT"

--- a/tests/cli/test_materialize.py
+++ b/tests/cli/test_materialize.py
@@ -58,9 +58,7 @@ def test_materialize_with_model_options(materialize: MagicMock):
 
 @patch("amora.cli.materialization.materialize")
 @patch("amora.cli.materialization.DependencyDAG.draw")
-def test_materialize_with_draw_dag_option(
-    draw: MagicMock, _materialize: MagicMock
-):
+def test_materialize_with_draw_dag_option(draw: MagicMock, _materialize: MagicMock):
     result = runner.invoke(
         app,
         ["materialize", "--draw-dag"],

--- a/tests/models/heart_rate_over_100.py
+++ b/tests/models/heart_rate_over_100.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from amora.models import (
+    AmoraModel,
+    MaterializationTypes,
+    ModelConfig,
+    Field,
+)
+from tests.models.heart_rate import HeartRate
+
+
+class HeartRateOver100(AmoraModel, table=True):
+    __tablename__ = "heart_rate_over_100"
+    __depends_on__ = [HeartRate]
+    __model_config__ = ModelConfig(
+        materialized=MaterializationTypes.view,
+        labels={"freshness": "daily"},
+    )
+
+    unit: str
+    value: float
+    creationDate: datetime
+    id: int = Field(primary_key=True)

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -65,9 +65,7 @@ def test_has_at_least_one_not_null_value_without_non_null_value():
         ]
     )
 
-    assert not that(
-        cte.c.col, has_at_least_one_not_null_value, raise_on_fail=False
-    )
+    assert not that(cte.c.col, has_at_least_one_not_null_value, raise_on_fail=False)
 
 
 def test_is_a_non_empty_string():

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -37,9 +37,7 @@ def test_amora_model_for_path_with_invalid_bytecode_python_file_path():
 
 
 def test_amora_model_for_path_with_valid_python_file_path():
-    model = amora_model_for_path(
-        path=Path(__file__).parent.joinpath("models/steps.py")
-    )
+    model = amora_model_for_path(path=Path(__file__).parent.joinpath("models/steps.py"))
     assert issubclass(model, AmoraModel)
 
 
@@ -55,9 +53,7 @@ def test_AmoraBigQueryCompiler_array__getitem__with_integer_item():
 
 
 def test_AmoraBigQueryCompiler_array__getitem__with_function_item():
-    version = func.split("123.45", ".", type_=BQArray(String))[
-        func.safe_ordinal(2)
-    ]
+    version = func.split("123.45", ".", type_=BQArray(String))[func.safe_ordinal(2)]
     statement = select(func.cast(version, Integer))
     query_str = compile_statement(statement)
 

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -24,9 +24,7 @@ def setup_function(module):
 
 
 def test_it_creates_a_task_from_a_target_file_path():
-    target_path = HeartRate.target_path(
-        model_file_path=HeartRate.model_file_path()
-    )
+    target_path = HeartRate.target_path(model_file_path=HeartRate.model_file_path())
     target_path.write_text("SELECT 1")
     task = Task.for_target(target_path)
 
@@ -133,9 +131,7 @@ def test_materialize_as_table(QueryJobConfig: MagicMock, Client: MagicMock):
 @patch("amora.materialization.Client", spec=Client)
 def test_materialize_as_ephemeral(Client: MagicMock):
     table_name = uuid4().hex
-    table_id = (
-        f"{settings.TARGET_PROJECT}.{settings.TARGET_SCHEMA}.{table_name}"
-    )
+    table_id = f"{settings.TARGET_PROJECT}.{settings.TARGET_SCHEMA}.{table_name}"
 
     class EphemeralModel(AmoraModel, table=True):
         __tablename__ = table_name


### PR DESCRIPTION
- 🐛 Corrige implementação de `amora.providers.bigquery.dry_run` que falhava ao ser executado em modelos sem source, que referenciam uma tabela
- 🎨 Remove regra de `line-length` customizada da verificação do black
- ✨ Adiciona logger e verbosidade ao tentar compilar um modelo com erro sintático