### PR TITLE
Validação automática de schemas de modelos

### DIFF
--- a/amora/models.py
+++ b/amora/models.py
@@ -10,7 +10,7 @@ from typing import Iterable, List, Optional, Union, Dict, Any, Tuple, Type
 from amora.logger import logger
 from amora.protocols import CompilableProtocol
 from amora.config import settings
-from sqlalchemy import MetaData, Table, select
+from sqlalchemy import MetaData, Table, select, Column
 from sqlmodel import SQLModel, Field, create_engine, Session
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.orm import declared_attr
@@ -18,8 +18,9 @@ from amora.types import Compilable
 from amora.utils import model_path_for_target_path, list_files
 
 select = select
-Column = ColumnElement
-Columns = Iterable[Column]
+Column = Column
+ColumnElement = ColumnElement
+Columns = Iterable[ColumnElement]
 Field = Field
 Model = Type["AmoraModel"]
 MetaData = MetaData

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -141,9 +141,12 @@ def get_schema_for_source(model: Model) -> Optional[Schema]:
     Give an `Amora Model`, returns the bigquery `Schema` of its
     `source` classmethod query result
     """
+    source = model.source()
+    if source is None:
+        return None
+
     result = dry_run(model)
-    if result:
-        return result.schema
+    return result.schema
 
 
 def run(statement: Compilable) -> RunResult:

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -146,6 +146,9 @@ def get_schema_for_source(model: Model) -> Optional[Schema]:
         return None
 
     result = dry_run(model)
+    if result is None:
+        return None
+
     return result.schema
 
 

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -65,7 +65,7 @@ SQLALCHEMY_TYPES_TO_BIGQUERY_TYPES = {
     DateTime: "DATETIME",
     Date: "DATE",
     Time: "TIME",
-    Float: "FLOAT64",
+    Float: "FLOAT",
     Boolean: "BOOLEAN",
     JSON: "JSON",
     TIMESTAMP: "TIMESTAMP",
@@ -113,12 +113,19 @@ def get_fully_qualified_id(model: Model) -> str:
 
 
 def get_schema(table_id: str) -> Schema:
+    """
+    Given a `table_id`, returns the `Schema` of the table by querying BigQueries API
+    """
     client = get_client()
     table = client.get_table(table_id)
     return table.schema
 
 
 def get_schema_for_model(model: Model) -> Schema:
+    """
+    Given an `AmoraModel`, returns the equivalent bigquery `Schema`
+    of the model by parsing the model SQLAlchemy column schema
+    """
     columns = model.__table__.columns
     return [
         SchemaField(

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -15,7 +15,7 @@ from google.cloud.bigquery import (
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
 from sqlalchemy import (
     literal,
-    literal_column
+    literal_column,
     Integer,
     String,
     DateTime,

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -136,6 +136,16 @@ def get_schema_for_model(model: Model) -> Schema:
     ]
 
 
+def get_schema_for_source(model: Model) -> Optional[Schema]:
+    """
+    Give an `Amora Model`, returns the bigquery `Schema` of its
+    `source` classmethod query result
+    """
+    result = dry_run(model)
+    if result:
+        return result.schema
+
+
 def run(statement: Compilable) -> RunResult:
     """
     Executes a given query and returns its results

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -11,7 +11,7 @@ from sqlalchemy import (
 )
 from sqlmodel.sql.expression import SelectOfScalar
 from amora.config import settings
-from amora.models import select, AmoraModel, Session, Column, Columns
+from amora.models import select, AmoraModel, Session, ColumnElement, Columns
 from amora.storage import local_engine
 from amora.tests.audit import AuditLog
 from amora.types import Compilable
@@ -64,7 +64,7 @@ def _test(statement: Compilable, raise_on_fail: bool = True) -> bool:
 
 
 def that(
-    column: Column,
+    column: ColumnElement,
     test: Test,
     raise_on_fail: bool = True,
     **test_kwargs,
@@ -86,7 +86,7 @@ def that(
     return _test(statement=test(column, **test_kwargs), raise_on_fail=raise_on_fail)
 
 
-def is_not_null(column: Column) -> Compilable:
+def is_not_null(column: ColumnElement) -> Compilable:
     """
     Asserts that the `column` does not contain `null` values
 
@@ -108,7 +108,7 @@ def is_not_null(column: Column) -> Compilable:
     return select(column).where(column == None)
 
 
-def is_unique(column: Column) -> Compilable:
+def is_unique(column: ColumnElement) -> Compilable:
     """
     Assert that the `column` values are unique
 
@@ -134,7 +134,7 @@ def is_unique(column: Column) -> Compilable:
     return select(column).group_by(column).having(func.count(column) > 1)
 
 
-def has_accepted_values(column: Column, values: Iterable) -> Compilable:
+def has_accepted_values(column: ColumnElement, values: Iterable) -> Compilable:
     """
     Assert that the values from the `column` should be one of the provided `values`
 
@@ -156,8 +156,8 @@ def has_accepted_values(column: Column, values: Iterable) -> Compilable:
 
 
 def relationship(
-    from_: Column,
-    to: Column,
+    from_: ColumnElement,
+    to: ColumnElement,
     from_condition=None,
     to_condition=None,
 ) -> bool:
@@ -240,7 +240,7 @@ def relationship(
     return _test(statement=exceptions)
 
 
-def is_numeric(column: Column) -> Compilable:
+def is_numeric(column: ColumnElement) -> Compilable:
     """
     Asserts that each not null value is a number
 
@@ -264,7 +264,7 @@ def is_numeric(column: Column) -> Compilable:
     return select(column).where(func.REGEXP_CONTAINS(column, "[^0-9]"))
 
 
-def is_non_negative(column: Column) -> Compilable:
+def is_non_negative(column: ColumnElement) -> Compilable:
     """
     Asserts that every column value should be >= 0
 
@@ -285,7 +285,7 @@ def is_non_negative(column: Column) -> Compilable:
     return select(column).where(column < 0)
 
 
-def is_a_non_empty_string(column: Column) -> Compilable:
+def is_a_non_empty_string(column: ColumnElement) -> Compilable:
     """
     Asserts that the column isn't an empty string
 
@@ -338,7 +338,7 @@ def expression_is_true(expression, condition=None) -> bool:
 def equality(
     model_a: AmoraModel,
     model_b: AmoraModel,
-    compare_columns: Optional[Iterable[Column]] = None,
+    compare_columns: Optional[Iterable[ColumnElement]] = None,
 ) -> bool:
     """
     This schema test asserts the equality of two models. Optionally specify a subset of columns to compare.
@@ -347,7 +347,7 @@ def equality(
 
     raise NotImplementedError
 
-    def comparable_columns(model: AmoraModel) -> Iterable[Column]:
+    def comparable_columns(model: AmoraModel) -> Iterable[ColumnElement]:
         if not compare_columns:
             return model
         return [getattr(model, column_name) for column_name in compare_columns]
@@ -364,7 +364,7 @@ def equality(
     return _test(statement=diff_union)
 
 
-def has_at_least_one_not_null_value(column: Column) -> Compilable:
+def has_at_least_one_not_null_value(column: ColumnElement) -> Compilable:
     """
     Asserts if column has at least one value.
 
@@ -388,7 +388,7 @@ def has_at_least_one_not_null_value(column: Column) -> Compilable:
     return select(func.count(column, type_=Integer)).having(func.count(column) == 0)
 
 
-def are_unique_together(columns: Iterable[Column]) -> Compilable:
+def are_unique_together(columns: Iterable[ColumnElement]) -> Compilable:
     """
     This test confirms that the combination of columns is unique.
     For example, the combination of month and product is unique,

--- a/amora/tests/generic_tests.py
+++ b/amora/tests/generic_tests.py
@@ -1,0 +1,46 @@
+"""
+Tests that can be reused by multiple projects
+"""
+from amora.models import list_models, MaterializationTypes
+from amora.providers.bigquery import (
+    get_schema,
+    get_schema_for_model,
+    get_schema_for_source,
+)
+
+
+def test_materialized_schema_equal_local_schema():
+    """
+    Validates that the current materialization has the same schema
+    as the locally defined model
+    """
+    for model, model_path in list_models():
+        if MaterializationTypes.ephemeral == model.__model_config__.materialized:
+            continue
+
+        materialized_schema = get_schema(model.unique_name)
+        model_schema = get_schema_for_model(model)
+
+        assert set(materialized_schema) == set(model_schema), (
+            f"Diff found between the materialized model `{model.unique_name}` "
+            f"schema and the local definition `{model_path}`"
+        )
+
+
+def test_models_schema_equal_its_source_schema():
+    """
+    Validates that the model schema matches its `source` classmethod result schema
+    """
+    for model, _model_path in list_models():
+        source = model.source()
+
+        if source is None:
+            continue
+
+        model_schema = get_schema_for_model(model)
+        source_schema = get_schema_for_source(model)
+
+        assert set(source_schema) == set(model_schema), (
+            f"Diff found between the schema of `source` classmethod "
+            f"and the model schema definition on `{model.unique_name}`"
+        )

--- a/amora/transformations.py
+++ b/amora/transformations.py
@@ -1,11 +1,11 @@
 from sqlalchemy import func, String, DateTime, Time, Date
-from amora.models import Column
+from amora.models import ColumnElement
 from sqlalchemy.sql.functions import Function
 
 from amora.providers.bigquery import TimePart
 
 
-def remove_non_numbers(column: Column) -> Function:
+def remove_non_numbers(column: ColumnElement) -> Function:
     """
     The column string value with numeric characters only.
 
@@ -14,7 +14,7 @@ def remove_non_numbers(column: Column) -> Function:
     return func.regexp_replace(column, "[^0-9]", "", type_=String)
 
 
-def remove_leading_zeros(column: Column) -> Function:
+def remove_leading_zeros(column: ColumnElement) -> Function:
     """
     The column string value without leading zeros.
 
@@ -23,7 +23,7 @@ def remove_leading_zeros(column: Column) -> Function:
     return func.regexp_replace(column, "^0+", "", type_=String)
 
 
-def parse_numbers(column: Column) -> Function:
+def parse_numbers(column: ColumnElement) -> Function:
     """
     Parses a string column as a number, returning NULL if value contains 0 numbers
 
@@ -35,7 +35,7 @@ def parse_numbers(column: Column) -> Function:
     )
 
 
-def datetime_trunc_hour(column: Column) -> Function:
+def datetime_trunc_hour(column: ColumnElement) -> Function:
     """
     Truncate a datetime column by its HOUR part.
     "2019-12-09T16:15:20" -> "2019-12-09T16:00:00"

--- a/amora/transformations.py
+++ b/amora/transformations.py
@@ -1,9 +1,9 @@
 from sqlalchemy import func, String
-from amora.models import Column
+from amora.models import ColumnElement
 from sqlalchemy.sql.functions import Function
 
 
-def remove_non_numbers(column: Column) -> Function:
+def remove_non_numbers(column: ColumnElement) -> Function:
     """
     The column string value with numeric characters only.
 
@@ -12,7 +12,7 @@ def remove_non_numbers(column: Column) -> Function:
     return func.regexp_replace(column, "[^0-9]", "", type_=String)
 
 
-def remove_leading_zeros(column: Column) -> Function:
+def remove_leading_zeros(column: ColumnElement) -> Function:
     """
     The column string value without leading zeros.
 
@@ -21,7 +21,7 @@ def remove_leading_zeros(column: Column) -> Function:
     return func.regexp_replace(column, "^0+", "", type_=String)
 
 
-def parse_numbers(column: Column) -> Function:
+def parse_numbers(column: ColumnElement) -> Function:
     """
     Parses a string column as a number, returning NULL if value contains 0 numbers
 

--- a/examples/amora_project/models/health.py
+++ b/examples/amora_project/models/health.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from amora.models import AmoraModel, ModelConfig, MaterializationTypes
+from sqlalchemy import TIMESTAMP
+
+from amora.models import AmoraModel, ModelConfig, MaterializationTypes, Column
 from sqlmodel import Field
 
 
@@ -10,13 +12,19 @@ class Health(AmoraModel, table=True):
         description="Health data exported by the Apple Health App",
     )
 
-    id: int = Field(primary_key=True)
-    type: str
-    sourceName: str
-    sourceVersion: str
-    unit: str
-    creationDate: datetime
-    startDate: datetime
-    endDate: datetime
-    value: float
-    device: str
+    id: int = Field(primary_key=True, description="Identificador único da medida")
+    type: str = Field(description="Tipo da métrica coletada")
+    sourceName: str = Field(description="Origem dos dados")
+    sourceVersion: str = Field(description="Versão da origem de dados")
+    unit: str = Field(description="Unidade de medida")
+    value: float = Field(description="Valor observado")
+    device: str = Field(description="Dispositivo de origem dos dados")
+    creationDate: datetime = Field(
+        description="Data de inserção dos dados", sa_column=Column(TIMESTAMP)
+    )
+    startDate: datetime = Field(
+        description="Data do início da medida", sa_column=Column(TIMESTAMP)
+    )
+    endDate: datetime = Field(
+        description="Data do fim da medida", sa_column=Column(TIMESTAMP)
+    )

--- a/examples/amora_project/models/heart_agg.py
+++ b/examples/amora_project/models/heart_agg.py
@@ -11,7 +11,7 @@ class HeartRateAgg(AmoraModel, table=True):
 
     avg: float
     sum: float
-    count: float
+    count: int
     year: int = Field(primary_key=True)
     month: int = Field(primary_key=True)
 

--- a/examples/amora_project/models/heart_rate.py
+++ b/examples/amora_project/models/heart_rate.py
@@ -1,11 +1,14 @@
 from datetime import datetime
 
+from sqlalchemy import TIMESTAMP
+
 from amora.types import Compilable
 from amora.models import (
     AmoraModel,
     ModelConfig,
     PartitionConfig,
     MaterializationTypes,
+    Column,
 )
 from examples.amora_project.models.health import Health
 from sqlmodel import Field, select
@@ -23,14 +26,20 @@ class HeartRate(AmoraModel, table=True):
         labels={"freshness": "daily"},
     )
 
-    creationDate: datetime
-    device: str
-    endDate: datetime
-    id: int = Field(primary_key=True)
-    sourceName: str
-    startDate: datetime
-    unit: str
-    value: float
+    id: int = Field(primary_key=True, description="Identificador único da medida")
+    sourceName: str = Field(description="Origem dos dados")
+    unit: str = Field(description="Unidade de medida", default="count/min")
+    value: float = Field(description="Valor observado")
+    device: str = Field(description="Dispositivo de origem dos dados")
+    creationDate: datetime = Field(
+        description="Data de inserção dos dados", sa_column=Column(TIMESTAMP)
+    )
+    startDate: datetime = Field(
+        description="Data do início da medida", sa_column=Column(TIMESTAMP)
+    )
+    endDate: datetime = Field(
+        description="Data do fim da medida", sa_column=Column(TIMESTAMP)
+    )
 
     @classmethod
     def source(cls) -> Compilable:

--- a/examples/amora_project/models/heart_rate_over_100.py
+++ b/examples/amora_project/models/heart_rate_over_100.py
@@ -1,12 +1,15 @@
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy import TIMESTAMP
+
 from amora.models import (
     AmoraModel,
     select,
     MaterializationTypes,
     ModelConfig,
     Field,
+    Column,
 )
 from amora.types import Compilable
 from examples.amora_project.models.heart_rate import HeartRate
@@ -20,10 +23,12 @@ class HeartRateOver100(AmoraModel, table=True):
         labels={"freshness": "daily"},
     )
 
-    unit: str
-    value: float
-    creationDate: datetime
-    id: int = Field(primary_key=True)
+    unit: str = Field(description="Unidade de medida")
+    value: float = Field(description="Valor observado")
+    creationDate: datetime = Field(
+        description="Data de inserção dos dados", sa_column=Column(TIMESTAMP)
+    )
+    id: int = Field(primary_key=True, description="Identificador único da medida")
 
     @classmethod
     def source(cls) -> Optional[Compilable]:

--- a/examples/amora_project/models/steps.py
+++ b/examples/amora_project/models/steps.py
@@ -1,11 +1,14 @@
 from datetime import datetime
 
+from sqlalchemy import TIMESTAMP
+
 from amora.compilation import Compilable
 from amora.models import (
     AmoraModel,
     ModelConfig,
     PartitionConfig,
     MaterializationTypes,
+    Column,
 )
 from examples.amora_project.models.health import Health
 from sqlmodel import Field, select
@@ -20,16 +23,24 @@ class Steps(AmoraModel, table=True):
         ),
         cluster_by=["sourceName"],
         labels={"freshness": "daily"},
+        description="Health automatically counts your steps, walking, and "
+        "running distances. This table stores step measurement events",
     )
 
-    creationDate: datetime
-    device: str
-    endDate: datetime
-    id: int = Field(primary_key=True)
-    sourceName: str
-    startDate: datetime
-    unit: str
-    value: float
+    id: int = Field(primary_key=True, description="Identificador único da medida")
+    sourceName: str = Field(description="Origem dos dados")
+    unit: str = Field(description="Unidade de medida", default="count")
+    value: float = Field(description="Valor observado")
+    device: str = Field(description="Dispositivo de origem dos dados")
+    creationDate: datetime = Field(
+        description="Data de inserção dos dados", sa_column=Column(TIMESTAMP)
+    )
+    startDate: datetime = Field(
+        description="Data do início da medida", sa_column=Column(TIMESTAMP)
+    )
+    endDate: datetime = Field(
+        description="Data do fim da medida", sa_column=Column(TIMESTAMP)
+    )
 
     @classmethod
     def source(cls) -> Compilable:

--- a/examples/amora_project/models/steps_agg.py
+++ b/examples/amora_project/models/steps_agg.py
@@ -11,7 +11,7 @@ class StepsAgg(AmoraModel, table=True):
 
     avg: float
     sum: float
-    count: float
+    count: int
     year: int = Field(primary_key=True)
     month: int = Field(primary_key=True)
 

--- a/examples/amora_project/tests/test_models_schema.py
+++ b/examples/amora_project/tests/test_models_schema.py
@@ -1,0 +1,4 @@
+from amora.tests.generic_tests import (
+    test_models_schema_equal_its_source_schema,
+    test_materialized_schema_equal_local_schema,
+)

--- a/tests/models/health.py
+++ b/tests/models/health.py
@@ -6,13 +6,13 @@ from amora.models import AmoraModel
 
 
 class Health(AmoraModel, table=True):
-    id: int = Field(primary_key=True)
-    type: str
-    sourceName: str
-    sourceVersion: str
-    unit: str
-    creationDate: datetime
-    startDate: datetime
-    endDate: datetime
-    value: float
-    device: str
+    creationDate: datetime = Field(description="Data de inserção dos dados")
+    device: str = Field(description="Dispositivo de origem dos dados")
+    endDate: datetime = Field(description="Data do fim da medida")
+    id: int = Field(primary_key=True, description="Identificador único da medida")
+    sourceName: str = Field(description="Origem dos dados")
+    sourceVersion: str = Field(description="Versão da origem de dados")
+    startDate: datetime = Field(description="Data do início da medida")
+    type: str = Field(description="Tipo da métrica coletada")
+    unit: str = Field(description="Unidade de medida")
+    value: float = Field(description="Valor observado")

--- a/tests/models/heart_agg.py
+++ b/tests/models/heart_agg.py
@@ -10,7 +10,7 @@ class HeartRateAgg(AmoraModel, table=True):
 
     _avg: float
     _sum: float
-    _count: float
+    _count: int
     year: int = Field(primary_key=True)
     month: int = Field(primary_key=True)
 

--- a/tests/models/heart_rate_over_100.py
+++ b/tests/models/heart_rate_over_100.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 
+from sqlalchemy import TIMESTAMP
+
 from amora.models import (
     AmoraModel,
     MaterializationTypes,
     ModelConfig,
     Field,
+    Column,
 )
 from tests.models.heart_rate import HeartRate
 
@@ -17,7 +20,9 @@ class HeartRateOver100(AmoraModel, table=True):
         labels={"freshness": "daily"},
     )
 
-    unit: str
-    value: float
-    creationDate: datetime
-    id: int = Field(primary_key=True)
+    unit: str = Field(description="Unidade de medida")
+    value: float = Field(description="Valor observado")
+    creationDate: datetime = Field(
+        description="Data de inserção dos dados", sa_column=Column(TIMESTAMP)
+    )
+    id: int = Field(primary_key=True, description="Identificador único da medida")


### PR DESCRIPTION
- ✨ Adiciona função para inferir o schema do BigQuery de um modelo amora
- ✨ Adiciona função para descobrir o schema do BigQuery a partir do _classmethod_ `source` de um modelo amora
- ✨ Adiciona função para descobrir o schema de um modelo amora materializado
- 🐛 Corrige schemas e adiciona documentação a modelos de exemplo/teste
- 🧪 Adiciona testes genéricos, que podem ser reutilizados por múltiplos projetos
  - `test_materialized_schema_equal_local_schema`: Teste garante que o modelo materializado como view/tabela tem o mesmo schema do modelo definido localmente.
  - `test_models_schema_equal_its_source_schema`: Teste que garante que o modelo definido localmente tem o mesmo schema do que o resultado de `source`, query responsável por materializá-lo.

## Testes Genéricos

Testes pytest que podem (devem?) ser reutilizados por qualquer projeto. Para utilizar, basta importar os testes em um arquivo de testes do projeto, como feito em `examples/amora_project/tests/test_models_schema.py`

https://user-images.githubusercontent.com/6271498/162436188-dc456c70-e2c2-46be-8eeb-2afa4c2fe86b.mov

## To-do
- [ ] Adicionar documentação sobre testes genéricos