### PR TITLE
Fix/amora model for path

### DIFF
--- a/amora/models.py
+++ b/amora/models.py
@@ -150,7 +150,7 @@ class AmoraModel(SQLModel):
 
 
 def amora_model_for_path(path: Path) -> Model:
-    spec = spec_from_file_location(path.stem, path)
+    spec = spec_from_file_location(".".join(["amoramodel", path.stem]), path)
     if spec is None:
         raise ValueError(f"Invalid path `{path}`. Not a valid Python file.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amora"
-version = "0.1.10rc6"
+version = "0.1.10rc7"
 description = "Amora Data Build Tool"
 authors = ["diogommartins <diogo.martins@stone.com.br>"]
 license = "MIT"


### PR DESCRIPTION
- 🐛 Fixes a bug in `amora.models.amora_model_for_path` that would cause module name conflicts