### PR TITLE
`AMORA_FEATURE_STORE_TQDM_ASCII_LOGGING` and `AMORA_FEATURE_STORE_TQDM_DISABLE`

### DIFF
--- a/amora/cli.py
+++ b/amora/cli.py
@@ -441,7 +441,10 @@ def feature_store_materialize(
     names using `--models`, all registered Feature Views will be materialized.
     """
     from amora.feature_store import fs
+    from amora.feature_store.logging import patch_tqdm
     from amora.feature_store.registry import get_repo_contents
+
+    patch_tqdm()
 
     repo_contents = get_repo_contents()
 
@@ -473,7 +476,10 @@ def feature_store_materialize_incremental(
 
     """
     from amora.feature_store import fs
+    from amora.feature_store.logging import patch_tqdm
     from amora.feature_store.registry import get_repo_contents
+
+    patch_tqdm()
 
     repo_contents = get_repo_contents()
 

--- a/amora/feature_store/config.py
+++ b/amora/feature_store/config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import BaseSettings
 
@@ -42,6 +42,9 @@ class FeatureStoreSettings(BaseSettings):
     HTTP_SERVER_HOST: str = "0.0.0.0"
     HTTP_SERVER_PORT: int = 8666
     HTTP_ACCESS_LOG_ENABLED: bool = False
+
+    TQDM_ASCII_LOGGING: bool = False
+    TQDM_DISABLE: Optional[bool] = None
 
     class Config:
         env_prefix = "AMORA_FEATURE_STORE_"

--- a/amora/feature_store/logging.py
+++ b/amora/feature_store/logging.py
@@ -1,0 +1,22 @@
+from amora.feature_store import settings
+
+
+def patch_tqdm() -> None:
+    """
+    Monkey patch tqdm logging to use only ASCII characters, instead of the default UNICODE format
+    """
+    from feast import feature_store
+
+    def patched_tqdm(*args, **kwargs):
+        from tqdm import tqdm
+
+        return tqdm(
+            *args,
+            **kwargs,
+            # If true, use ASCII characters ' 123456789#' instead of unicode (smooth blocks) to fill the meter.
+            ascii=settings.TQDM_ASCII_LOGGING,
+            # Whether to disable the entire progressbar wrapper. If set to None, disable on non-TTY.
+            disable=settings.TQDM_DISABLE,
+        )
+
+    feature_store.tqdm = patched_tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amora"
-version = "0.1.10rc9"
+version = "0.1.10"
 description = "Amora Data Build Tool"
 authors = ["diogommartins <diogo.martins@stone.com.br>"]
 license = "MIT"


### PR DESCRIPTION
-  ✨ Adds the possibility of using tqdm ASCII logging through feast monkeypatch and `AMORA_FEATURE_STORE_TQDM_ASCII_LOGGING` and `AMORA_FEATURE_STORE_TQDM_DISABLE` config