### PR TITLE
DTREX-649 Makes feast usage tracking opt-in. Default: No tracking

### DIFF
--- a/amora/cli/feature_store.py
+++ b/amora/cli/feature_store.py
@@ -85,10 +85,7 @@ def feature_store_materialize(
     names using `--models`, all registered Feature Views will be materialized.
     """
     from amora.feature_store import fs
-    from amora.feature_store.logging import patch_tqdm
     from amora.feature_store.registry import get_repo_contents
-
-    patch_tqdm()
 
     repo_contents = get_repo_contents()
 
@@ -120,10 +117,7 @@ def feature_store_materialize_incremental(
 
     """
     from amora.feature_store import fs
-    from amora.feature_store.logging import patch_tqdm
     from amora.feature_store.registry import get_repo_contents
-
-    patch_tqdm()
 
     repo_contents = get_repo_contents()
 

--- a/amora/feature_store/__init__.py
+++ b/amora/feature_store/__init__.py
@@ -1,6 +1,11 @@
 from feast import FeatureStore, RepoConfig
 
 from amora.feature_store.config import settings
+from amora.feature_store.logging import patch_tqdm
+from amora.feature_store.usage_tracking import patch_usage
+
+patch_usage()
+patch_tqdm()
 
 repo_config = RepoConfig(
     registry=settings.REGISTRY,

--- a/amora/feature_store/config.py
+++ b/amora/feature_store/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Optional
 
+from feast.usage import USAGE_ENDPOINT as FEAST_USAGE_ENDPOINT
 from pydantic import BaseSettings
 
 from amora.config import ROOT_PATH
@@ -45,6 +46,9 @@ class FeatureStoreSettings(BaseSettings):
 
     TQDM_ASCII_LOGGING: bool = False
     TQDM_DISABLE: Optional[bool] = None
+
+    USAGE_TRACKING_ENABLED: bool = False
+    USAGE_ENDPOINT: str = FEAST_USAGE_ENDPOINT
 
     class Config:
         env_prefix = "AMORA_FEATURE_STORE_"

--- a/amora/feature_store/usage_tracking.py
+++ b/amora/feature_store/usage_tracking.py
@@ -12,9 +12,6 @@ def patch_usage() -> None:
     from feast import usage
     from feast.constants import FEAST_USAGE
 
-    if settings.USAGE_TRACKING_ENABLED:
-        return
-
     os.environ[FEAST_USAGE] = str(settings.USAGE_TRACKING_ENABLED)
 
     usage._is_enabled = settings.USAGE_TRACKING_ENABLED

--- a/amora/feature_store/usage_tracking.py
+++ b/amora/feature_store/usage_tracking.py
@@ -1,0 +1,21 @@
+import os
+
+from amora.feature_store.config import settings
+
+
+def patch_usage() -> None:
+    """
+    By default, feast tracks user activity. We believe that should be an opt-in feature, instead of opt-out.
+
+    Reference: https://docs.feast.dev/reference/usage
+    """
+    from feast import usage
+    from feast.constants import FEAST_USAGE
+
+    if settings.USAGE_TRACKING_ENABLED:
+        return
+
+    os.environ[FEAST_USAGE] = str(settings.USAGE_TRACKING_ENABLED)
+
+    usage._is_enabled = settings.USAGE_TRACKING_ENABLED
+    usage.USAGE_ENDPOINT = settings.USAGE_ENDPOINT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amora"
-version = "0.1.11rc1"
+version = "0.1.11rc2"
 description = "Amora Data Build Tool"
 authors = ["diogommartins <diogo.martins@stone.com.br>"]
 license = "MIT"

--- a/tests/feature_store/test_usage_tracking.py
+++ b/tests/feature_store/test_usage_tracking.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from amora.feature_store import patch_usage, settings
+
+
+def test_patch_usage_default_behaviour():
+    with patch("feast.usage") as usage:
+        patch_usage()
+
+        assert not usage._is_enabled
+        assert usage.USAGE_ENDPOINT == "https://usage.feast.dev"
+
+
+def test_patch_usage_custom_tracking_endpoint():
+    usage_endpoint = "https://we-wont-track-you.stone.co"
+
+    with patch.multiple(
+        settings, USAGE_ENDPOINT=usage_endpoint, USAGE_TRACKING_ENABLED=True
+    ), patch("feast.usage") as usage:
+        patch_usage()
+
+        assert usage._is_enabled
+        assert usage.USAGE_ENDPOINT == usage_endpoint
+
+
+def test_patch_usage_with_tracking_on_default_endpoint():
+    with patch.multiple(settings, USAGE_TRACKING_ENABLED=True), patch(
+        "feast.usage"
+    ) as usage:
+        patch_usage()
+
+        assert usage._is_enabled
+        assert usage.USAGE_ENDPOINT == "https://usage.feast.dev"


### PR DESCRIPTION
- 🐛 Makes feast usage tracking opt-in. Default: No tracking
- ✨ Enables a custom destination for feature store related (error tracking, usage statistic collection and time profiling) tracking through `AMORA_FEATURE_STORE_USAGE_TRACKING_ENABLED` and `AMORA_FEATURE_STORE_USAGE_ENDPOINT`