### PR TITLE
fix(models): Performance improvement on `amora.models.list_models`

### DIFF
--- a/amora/models.py
+++ b/amora/models.py
@@ -201,6 +201,8 @@ def list_models(
     path: Path = settings.MODELS_PATH,
 ) -> Iterable[Tuple[Model, Path]]:
     for model_file_path in list_files(path, suffix=".py"):
+        if model_file_path.stem.startswith("_"):
+            continue
         try:
             yield amora_model_for_path(model_file_path), model_file_path
         except ValueError:


### PR DESCRIPTION
No need to try to interpret files prefixed with underscore (`_`)