### PR TITLE
DTREX-686 :: amora[dash] :: `amora.dash.pages.feature_store` page refactor

### DIFF
--- a/amora/dash/components/model_columns.py
+++ b/amora/dash/components/model_columns.py
@@ -1,6 +1,5 @@
-import dash_table
 import pandas as pd
-from dash import html
+from dash import dash_table, html
 from dash.development.base_component import Component
 
 from amora.models import Model

--- a/amora/dash/components/model_columns.py
+++ b/amora/dash/components/model_columns.py
@@ -1,0 +1,28 @@
+import dash_table
+import pandas as pd
+from dash import html
+from dash.development.base_component import Component
+
+from amora.models import Model
+
+
+def component(model: Model) -> Component:
+    df = pd.DataFrame(
+        [
+            {
+                "column": col.key,
+                "description": col.comment if col.comment else "Undocumented",
+            }
+            for col in model.__table__.columns
+        ]
+    )
+    return html.Div(
+        dash_table.DataTable(
+            data=df.to_dict("records"),
+            columns=[
+                {"name": "column", "id": "column"},
+                {"name": "description", "id": "description"},
+            ],
+        ),
+        id=f"model-columns-{model.unique_name}",
+    )

--- a/amora/dash/components/model_datatable.py
+++ b/amora/dash/components/model_datatable.py
@@ -1,0 +1,14 @@
+import dash_table
+
+from amora.models import Model
+from amora.providers.bigquery import sample
+
+
+def component(model: Model) -> dash_table.DataTable:
+    df = sample(model, percentage=1)
+    return dash_table.DataTable(
+        data=df.to_dict("records"),
+        columns=[{"name": col, "id": col} for col in sorted(df.columns.values)],
+        export_format="csv",
+        sort_action="native",
+    )

--- a/amora/dash/components/model_labels.py
+++ b/amora/dash/components/model_labels.py
@@ -1,0 +1,14 @@
+import dash_bootstrap_components as dbc
+from dash import html
+from dash.development.base_component import Component
+
+from amora.models import Model
+
+
+def component(model: Model) -> Component:
+    return html.Span(
+        [
+            dbc.Badge(f"{key}: {value}", color="info")
+            for key, value in model.__model_config__.labels.items()
+        ]
+    )

--- a/amora/logger.py
+++ b/amora/logger.py
@@ -1,8 +1,61 @@
 import logging
 import sys
+import time
+from datetime import timedelta
+from functools import wraps
+from typing import Callable
+
+import humanize
 
 from amora.config import settings
 
 logger = logging.getLogger("amora")
 logger.setLevel(settings.LOGGER_LOG_LEVEL)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+
+
+def log_execution():
+    """
+    Wraps the execution of a function, calculates the execution time and logs the
+    result in a human readable way. E.g:
+
+    ```python
+    from time import sleep
+
+    from amora import logger
+
+
+    @logger.log_execution()
+    def do_something():
+        sleep(3)
+        return 42
+
+
+    do_something()
+    ```
+
+    Would result in the log
+    ```
+    Function call to `a_module.do_something` took 3 seconds
+    ```
+
+    """
+
+    def wrapper(fn: Callable):
+        @wraps(fn)
+        def decorator(*args, **kwargs):
+            t0 = time.perf_counter()
+
+            result = fn(*args, **kwargs)
+
+            execution_delta = timedelta(seconds=time.perf_counter() - t0)
+            f_name = f"{fn.__module__}.{fn.__qualname__}"
+            delta = humanize.naturaldelta(execution_delta, minimum_unit="milliseconds")
+
+            logger.debug(f"Function call to `{f_name}` took {delta}")
+
+            return result
+
+        return decorator
+
+    return wrapper

--- a/examples/amora_project/models/step_count_by_source.py
+++ b/examples/amora_project/models/step_count_by_source.py
@@ -14,17 +14,29 @@ from examples.amora_project.models.steps import Steps
 @feature_view
 class StepCountBySource(AmoraModel, table=True):
     __depends_on__ = [Steps]
-    __model_config__ = ModelConfig(materialized=MaterializationTypes.table)
+    __model_config__ = ModelConfig(
+        materialized=MaterializationTypes.table,
+        labels={"quality": "golden", "upstream": "apple_health", "domain": "health"},
+    )
 
-    value_avg: float = Field(description="Average step count of the hour")
-    value_sum: float = Field(description="Sum of the step counts of the hour")
-    value_count: float = Field(description="Count of step count samples of the hour")
+    value_avg: float = Field(
+        sa_column_kwargs=dict(comment="Average step count of the hour")
+    )
+    value_sum: float = Field(
+        sa_column_kwargs=dict(comment="Sum of the step counts of the hour")
+    )
+    value_count: float = Field(
+        sa_column_kwargs=dict(comment="Count of step count samples of the hour")
+    )
 
-    source_name: str = Field(primary_key=True, description="Source of the metric")
+    source_name: str = Field(
+        primary_key=True, sa_column_kwargs=dict(comment="Source of the metric")
+    )
     event_timestamp: datetime = Field(
         primary_key=True,
-        sa_column=Column(TIMESTAMP),
-        description="Moment if time of which those features where observed",
+        sa_column=Column(
+            TIMESTAMP, comment="Moment if time of which those features where observed"
+        ),
     )
 
     @classmethod
@@ -56,6 +68,9 @@ class StepCountBySource(AmoraModel, table=True):
     def feature_view_event_timestamp(cls):
         return cls.event_timestamp
 
+    @classmethod
+    def feature_view_fa_icon(cls):
+        return "fa-person-running"
 
 @question
 def how_many_data_points_where_acquired():

--- a/examples/amora_project/models/step_count_by_source.py
+++ b/examples/amora_project/models/step_count_by_source.py
@@ -21,7 +21,11 @@ class StepCountBySource(AmoraModel, table=True):
     value_count: float = Field(description="Count of step count samples of the hour")
 
     source_name: str = Field(primary_key=True, description="Source of the metric")
-    event_timestamp: datetime = Field(primary_key=True, sa_column=Column(TIMESTAMP))
+    event_timestamp: datetime = Field(
+        primary_key=True,
+        sa_column=Column(TIMESTAMP),
+        description="Moment if time of which those features where observed",
+    )
 
     @classmethod
     def source(cls) -> Optional[Compilable]:

--- a/tests/models/step_count_by_source.py
+++ b/tests/models/step_count_by_source.py
@@ -51,3 +51,7 @@ class StepCountBySource(AmoraModel, table=True):
     @classmethod
     def feature_view_event_timestamp(cls):
         return cls.event_timestamp
+
+    @classmethod
+    def feature_view_fa_icon(cls):
+        return "fa-person-running"


### PR DESCRIPTION
- feat(dash): Refactors `amora.dash.pages.feature_store` page
  - Adds feature view icon
  - Adds a `dash.DataTable` for feature data sample
  - Adds columns description
- feat(dash): Adds column description and feature view icon to `step_count_by_source.py` model
- feat(dash): Adds `amora.dash.components.model_columns`, a component to render the model columns descriptions/documentation 
- feat(dash): Adds `amora.dash.components.model_labels`, a component to render the model labels (`amora.models.ModelConfig.labels`)
- feat(bigquery): Caches `amora.providers.bigquery.sample` results for 1 day
- feat(logger): Adds `amora.logger.log_execution`. The decorator wraps the execution of a function, calculates the execution time and logs the result in a human readable way

## Model labels
![Screen Shot 2022-07-17 at 12 57 29](https://user-images.githubusercontent.com/6271498/179408044-67b93020-8232-41c4-a9eb-eb181e0c6c0c.png)

## Columns Documentation

<img width="694" alt="Screen Shot 2022-07-17 at 18 59 18" src="https://user-images.githubusercontent.com/6271498/179426345-89d9e8d2-49ed-46e7-8b53-2979ac762457.png">

## Sample dataset
![Screen Shot 2022-07-17 at 12 50 03](https://user-images.githubusercontent.com/6271498/179408066-f9d5b341-bebb-4036-8ad7-17b533e0dfb4.png)

Table samples currently doesn't support models materialized as views

💡 In the future, we could render model labels like GitHub Badges:
![Screen Shot 2022-07-17 at 12 46 36](https://user-images.githubusercontent.com/6271498/179406084-3dcd5051-f71a-4cec-a66d-923fa979c56c.png)

