### PR TITLE
New API for model selection by labels and minor models iteration fixes

### DIFF
--- a/amora/dash/components/model_labels.py
+++ b/amora/dash/components/model_labels.py
@@ -7,8 +7,5 @@ from amora.models import Model
 
 def component(model: Model) -> Component:
     return html.Span(
-        [
-            dbc.Badge(f"{key}: {value}", color="info")
-            for key, value in model.__model_config__.labels.items()
-        ]
+        [dbc.Badge(label, color="info") for label in model.__model_config__.labels]
     )

--- a/amora/dash/components/question_details.py
+++ b/amora/dash/components/question_details.py
@@ -15,7 +15,7 @@ def answer_visualization(visualization: Visualization) -> Component:
     elif isinstance(view_config, LineChart):
         return dcc.Graph(
             figure=px.line(
-                visualization.data,
+                data_frame=visualization.data,
                 x=view_config.x_func(visualization.data),
                 y=view_config.y_func(visualization.data),
             )
@@ -23,7 +23,9 @@ def answer_visualization(visualization: Visualization) -> Component:
     elif isinstance(view_config, PieChart):
         return dcc.Graph(
             figure=px.pie(
-                visualization.data, values=view_config.values, names=view_config.names
+                data_frame=visualization.data,
+                values=view_config.values,
+                names=view_config.names,
             )
         )
     else:

--- a/amora/dash/pages/dashboard.py
+++ b/amora/dash/pages/dashboard.py
@@ -66,6 +66,4 @@ def layout(dashboard_id: str = None) -> Component:
     prevent_initial_call=True,
 )
 def update_dashboard_details(value: str) -> Component:
-    dashboard = DASHBOARDS.get(value)
-    component = render(dashboard)
-    return component
+    return render(dashboard=DASHBOARDS[value])

--- a/amora/dashboards.py
+++ b/amora/dashboards.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel
 
@@ -9,7 +9,7 @@ from amora.questions import Question
 class Filter(BaseModel):
     type: str
     id: str
-    default: str
+    default: Any
     title: str
 
 

--- a/amora/models.py
+++ b/amora/models.py
@@ -79,7 +79,8 @@ class Label(NamedTuple):
         return cls(*label.split(":"))
 
 
-Labels = Set[Union[Label, str]]
+LabelRepr = Union[Label, str]
+Labels = Set[Label]
 
 
 @dataclass
@@ -118,7 +119,7 @@ class ModelConfig:
     materialized: MaterializationTypes = MaterializationTypes.view
     partition_by: Optional[PartitionConfig] = None
     cluster_by: List[str] = field(default_factory=list)
-    labels: Labels = field(default_factory=list)
+    labels: Labels = field(default_factory=set)
 
 
 metadata = MetaData(schema=f"{settings.TARGET_PROJECT}.{settings.TARGET_SCHEMA}")
@@ -300,8 +301,8 @@ def select_models_with_label_keys(
 
 def match_label_keys(model: Model, label_keys: Iterable[LabelKey]) -> bool:
     for key in label_keys:
-        for (k, v) in model.__model_config__.labels:
-            if key == k:
+        for label in model.__model_config__.labels:
+            if label.key == key:
                 return True
     return False
 

--- a/amora/models.py
+++ b/amora/models.py
@@ -209,12 +209,14 @@ def amora_model_for_path(path: Path) -> Model:
     module = module_from_spec(spec)
 
     if spec.loader is None:
-        raise ValueError(f"Invalid path `{path}`. Unable to load module.")
+        raise ValueError(f"Invalid AmoraModel path `{path}`. Unable to load module.")
 
     try:
         spec.loader.exec_module(module)  # type: ignore
     except ImportError as e:
-        raise ValueError(f"Invalid path `{path}`. Unable to load module.") from e
+        raise ValueError(
+            f"Invalid AmoraModel path `{path}`. Unable to load module."
+        ) from e
     is_amora_model = (
         lambda x: isinstance(x, CompilableProtocol)
         and inspect.isclass(x)

--- a/amora/models.py
+++ b/amora/models.py
@@ -5,7 +5,18 @@ from enum import Enum, auto
 from importlib.util import module_from_spec, spec_from_file_location
 from inspect import getfile
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 from sqlalchemy import Column, MetaData, Table, select
 from sqlalchemy.orm import declared_attr
@@ -263,3 +274,38 @@ def list_models(
                 extra={"model_file_path": model_file_path},
             )
             continue
+
+
+def select_models_with_labels(labels: Labels) -> Iterable[Tuple[Model, Path]]:
+    def matches_labels(item: Tuple[Model, Path]) -> bool:
+        model, _model_path = item
+        return match_labels(model, labels)
+
+    return filter(matches_labels, list_models())
+
+
+def select_models_with_label_keys(
+    label_keys: LabelKeys,
+) -> Iterable[Tuple[Model, Path]]:
+    keys = set(label_keys)
+
+    def matches_labels(item: Tuple[Model, Path]) -> bool:
+        model, _model_path = item
+        return match_label_keys(model, keys)
+
+    return filter(matches_labels, list_models())
+
+
+def match_label_keys(model: Model, label_keys: Iterable[LabelKey]) -> bool:
+    for key in label_keys:
+        for (k, v) in model.__model_config__.labels:
+            if key == k:
+                return True
+    return False
+
+
+def match_labels(model: Model, labels: Labels) -> bool:
+    for label in labels:
+        if label in model.__model_config__.labels:
+            return True
+    return False

--- a/amora/models.py
+++ b/amora/models.py
@@ -217,7 +217,7 @@ def list_models(
         try:
             yield amora_model_for_path(model_file_path), model_file_path
         except ValueError:
-            logger.warning(
+            logger.exception(
                 "Unable to load amora model for path",
                 extra={"model_file_path": model_file_path},
             )

--- a/amora/questions.py
+++ b/amora/questions.py
@@ -86,11 +86,7 @@ class Question:
             )
 
         self.question_func = question_func
-
-        if view_config is None:
-            self.view_config = Table(title=self.name)
-        else:
-            self.view_config = view_config
+        self.view_config = view_config or Table(title=self.name)
 
     def __call__(self, *args, **kwargs):
         return self.question_func(*args, **kwargs)

--- a/amora/visualization.py
+++ b/amora/visualization.py
@@ -1,8 +1,19 @@
 from abc import ABC
-from typing import Callable, Union
+from typing import Any, Protocol, Union
 
 import pandas as pd
+from pandas import Series
 from pydantic import BaseModel
+
+
+class SeriesSelectorFunc(Protocol):
+    def __call__(self, df: pd.DataFrame) -> Series[Any]:
+        pass
+
+
+class ValueSelectorFunc(Protocol):
+    def __call__(self, df: pd.DataFrame) -> str:
+        pass
 
 
 class VisualizationConfig(ABC):
@@ -15,13 +26,13 @@ class PieChart(VisualizationConfig, BaseModel):
 
 
 class _2DChart(VisualizationConfig, BaseModel):
-    x_func: Callable[[pd.DataFrame], str] = lambda data: data["x"]
-    y_func: Callable[[pd.DataFrame], str] = lambda data: data["y"]
+    x_func: SeriesSelectorFunc = lambda data: data["x"]
+    y_func: SeriesSelectorFunc = lambda data: data["y"]
 
 
 class BarChart(VisualizationConfig, BaseModel):
-    x_func: Callable[[pd.DataFrame], str] = lambda data: data["x"]
-    y_func: Callable[[pd.DataFrame], str] = lambda data: data["y"]
+    x_func: SeriesSelectorFunc = lambda data: data["x"]
+    y_func: SeriesSelectorFunc = lambda data: data["y"]
 
 
 class LineChart(_2DChart):
@@ -29,7 +40,7 @@ class LineChart(_2DChart):
 
 
 class BigNumber(VisualizationConfig, BaseModel):
-    value_func: Callable[[pd.DataFrame], str] = lambda data: data["total"][0]
+    value_func: ValueSelectorFunc = lambda data: data["total"][0]
 
 
 class Table(VisualizationConfig, BaseModel):

--- a/examples/amora_project/models/heart_rate.py
+++ b/examples/amora_project/models/heart_rate.py
@@ -6,6 +6,7 @@ from sqlmodel import Field, select
 from amora.models import (
     AmoraModel,
     Column,
+    Label,
     MaterializationTypes,
     ModelConfig,
     PartitionConfig,
@@ -23,7 +24,7 @@ class HeartRate(AmoraModel, table=True):
             field="creationDate", data_type="TIMESTAMP", granularity="day"
         ),
         cluster_by=["sourceName"],
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
     )
 
     id: int = Field(primary_key=True, description="Identificador único da medida")

--- a/examples/amora_project/models/heart_rate_over_100.py
+++ b/examples/amora_project/models/heart_rate_over_100.py
@@ -7,6 +7,7 @@ from amora.models import (
     AmoraModel,
     Column,
     Field,
+    Label,
     MaterializationTypes,
     ModelConfig,
     select,
@@ -20,7 +21,7 @@ class HeartRateOver100(AmoraModel, table=True):
     __depends_on__ = [HeartRate]
     __model_config__ = ModelConfig(
         materialized=MaterializationTypes.view,
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
     )
 
     unit: str = Field(description="Unidade de medida")

--- a/examples/amora_project/models/step_count_by_source.py
+++ b/examples/amora_project/models/step_count_by_source.py
@@ -5,7 +5,14 @@ import humanize
 from sqlalchemy import TIMESTAMP, Column, Integer, func, literal
 
 from amora.feature_store.decorators import feature_view
-from amora.models import AmoraModel, Field, MaterializationTypes, ModelConfig, select
+from amora.models import (
+    AmoraModel,
+    Field,
+    Label,
+    MaterializationTypes,
+    ModelConfig,
+    select,
+)
 from amora.questions import question
 from amora.transformations import datetime_trunc_hour
 from amora.types import Compilable
@@ -18,7 +25,11 @@ class StepCountBySource(AmoraModel, table=True):
     __depends_on__ = [Steps]
     __model_config__ = ModelConfig(
         materialized=MaterializationTypes.table,
-        labels={"quality": "golden", "upstream": "apple_health", "domain": "health"},
+        labels=[
+            Label("quality", "golden"),
+            Label("upstream", "apple_health"),
+            Label("domain", "health"),
+        ],
     )
 
     value_avg: float = Field(

--- a/examples/amora_project/models/steps.py
+++ b/examples/amora_project/models/steps.py
@@ -7,6 +7,7 @@ from amora.compilation import Compilable
 from amora.models import (
     AmoraModel,
     Column,
+    Label,
     MaterializationTypes,
     ModelConfig,
     PartitionConfig,
@@ -22,7 +23,7 @@ class Steps(AmoraModel, table=True):
             field="creationDate", data_type="TIMESTAMP", granularity="day"
         ),
         cluster_by=["sourceName"],
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
         description="Health automatically counts your steps, walking, and "
         "running distances. This table stores step measurement events",
     )

--- a/tests/models/heart_rate.py
+++ b/tests/models/heart_rate.py
@@ -2,7 +2,13 @@ from datetime import datetime
 
 from sqlmodel import Field, select
 
-from amora.models import AmoraModel, MaterializationTypes, ModelConfig, PartitionConfig
+from amora.models import (
+    AmoraModel,
+    Label,
+    MaterializationTypes,
+    ModelConfig,
+    PartitionConfig,
+)
 from amora.types import Compilable
 
 from tests.models.health import Health
@@ -17,7 +23,7 @@ class HeartRate(AmoraModel, table=True):
             field="creationDate", data_type="TIMESTAMP", granularity="day"
         ),
         cluster_by=["sourceName"],
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
     )
 
     creationDate: datetime

--- a/tests/models/heart_rate_over_100.py
+++ b/tests/models/heart_rate_over_100.py
@@ -2,7 +2,14 @@ from datetime import datetime
 
 from sqlalchemy import TIMESTAMP
 
-from amora.models import AmoraModel, Column, Field, MaterializationTypes, ModelConfig
+from amora.models import (
+    AmoraModel,
+    Column,
+    Field,
+    Label,
+    MaterializationTypes,
+    ModelConfig,
+)
 
 from tests.models.heart_rate import HeartRate
 
@@ -12,7 +19,7 @@ class HeartRateOver100(AmoraModel, table=True):
     __depends_on__ = [HeartRate]
     __model_config__ = ModelConfig(
         materialized=MaterializationTypes.view,
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
     )
 
     unit: str = Field(description="Unidade de medida")

--- a/tests/models/step_count_by_source.py
+++ b/tests/models/step_count_by_source.py
@@ -4,7 +4,14 @@ from typing import Optional
 from sqlalchemy import TIMESTAMP, Column, func
 
 from amora.feature_store.decorators import feature_view
-from amora.models import AmoraModel, Field, MaterializationTypes, ModelConfig, select
+from amora.models import (
+    AmoraModel,
+    Field,
+    Label,
+    MaterializationTypes,
+    ModelConfig,
+    select,
+)
 from amora.transformations import datetime_trunc_hour
 from amora.types import Compilable
 
@@ -14,7 +21,15 @@ from tests.models.steps import Steps
 @feature_view
 class StepCountBySource(AmoraModel, table=True):
     __depends_on__ = [Steps]
-    __model_config__ = ModelConfig(materialized=MaterializationTypes.table)
+    __model_config__ = ModelConfig(
+        materialized=MaterializationTypes.table,
+        labels=[
+            Label("quality", "golden"),
+            Label("upstream", "apple_health"),
+            Label("downstream", "dashboards"),
+            Label("domain", "health"),
+        ],
+    )
 
     value_avg: float
     value_sum: float

--- a/tests/models/steps.py
+++ b/tests/models/steps.py
@@ -3,7 +3,13 @@ from datetime import datetime
 from sqlmodel import Field, select
 
 from amora.compilation import Compilable
-from amora.models import AmoraModel, MaterializationTypes, ModelConfig, PartitionConfig
+from amora.models import (
+    AmoraModel,
+    Label,
+    MaterializationTypes,
+    ModelConfig,
+    PartitionConfig,
+)
 
 from tests.models.health import Health
 
@@ -16,7 +22,7 @@ class Steps(AmoraModel, table=True):
             field="creationDate", data_type="TIMESTAMP", granularity="day"
         ),
         cluster_by=["sourceName"],
-        labels={"freshness": "daily"},
+        labels={Label("freshness", "daily")},
     )
 
     creationDate: datetime

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -8,6 +8,7 @@ from amora.materialization import Task, materialize
 from amora.models import (
     AmoraModel,
     Field,
+    Label,
     MaterializationTypes,
     ModelConfig,
     PartitionConfig,
@@ -69,7 +70,7 @@ def test_materialize_as_view(Client: MagicMock):
                 field="creationDate", data_type="TIMESTAMP", granularity="day"
             ),
             cluster_by=["sourceName"],
-            labels={"freshness": "daily"},
+            labels={Label("freshness", "daily")},
         )
 
     result = materialize(sql="SELECT 1", model=ViewModel)
@@ -101,7 +102,7 @@ def test_materialize_as_table(QueryJobConfig: MagicMock, Client: MagicMock):
                 field="created_at", data_type="TIMESTAMP", granularity="day"
             ),
             cluster_by=["x", "y"],
-            labels={"freshness": "daily"},
+            labels={Label("freshness", "daily")},
             description=uuid4().hex,
         )
 
@@ -148,7 +149,7 @@ def test_materialize_as_table_without_clustering_configuration(
             partition_by=PartitionConfig(
                 field="created_at", data_type="TIMESTAMP", granularity="day"
             ),
-            labels={"freshness": "daily"},
+            labels={Label("freshness", "daily")},
             description=uuid4().hex,
         )
 


### PR DESCRIPTION
- 💥 feat!(models): Changes `amora.models.ModelConfig` interface from  `labels: Dict[str, str]` to `labels: Labels`
- ✨ feat(models): Adds select functions to filter models by labels
  - `amora.models.select_models_with_labels`
  - `amora.models.select_models_with_label_keys`
- 📢 refactor(models): Improves error messages for `amora.models.amora_model_for_path`
- 📢 fix(logs): Fixes `amora.models.list_models` logging on exception
- 🐛 fix(mypy): Typing related fixes
---

Enabler for: 
- `--labels` CLI option:
  - `--labels freshness`: Selects all models with a `freshness` label key
  - `--labels freshness:daily`: Selects all models with a `freshness` label key, and a `daily` value
- Clickable `amora.dash.components.model_label` component, that could render a filtered `amora.dash.components.model_details` list