### PR TITLE
fix: Corrige hotkey para acionar sidebar

### DIFF
--- a/amora/dash/components/side_bar.py
+++ b/amora/dash/components/side_bar.py
@@ -53,7 +53,7 @@ def layout() -> Component:
             dmc.Center(id="user-account"),
             dmc.Center(
                 dbc.Alert(
-                    ["Press ", dmc.Kbd("⌘"), " to toggle the menu"], color="light"
+                    ["Press ", dmc.Kbd("m"), " to toggle the menu"], color="light"
                 )
             ),
         ],
@@ -83,6 +83,6 @@ def display_user(pathname):
 def toggle_menu_on_keydown(
     _n_events: Optional[int], is_open: bool, event: Optional[dict]
 ) -> bool:
-    if event and event["metaKey"]:
+    if event and event["key"] == "m":
         return not is_open
     return is_open


### PR DESCRIPTION
A tecla para acionar o menu agora é `m`