### PR TITLE
DTREX-681 :: UI :: Data Owner

### DIFF
--- a/amora/dash/components/model_data_owner.py
+++ b/amora/dash/components/model_data_owner.py
@@ -1,0 +1,18 @@
+import dash_core_components as dcc
+from dash import html
+from dash.development.base_component import Component
+
+from amora.models import Model
+
+
+def layout(model: Model) -> Component:
+    owner = model.owner()
+    if owner:
+        content = [
+            "Owner: ",
+            dcc.Link(model.owner(), href=f"/owners/{owner}"),
+        ]
+    else:
+        content = "Owner: Unowned"
+
+    return html.H6(children=content, id="model-data-owner")

--- a/amora/dash/components/model_data_owner.py
+++ b/amora/dash/components/model_data_owner.py
@@ -13,6 +13,6 @@ def layout(model: Model) -> Component:
             dcc.Link(model.owner(), href=f"/owners/{owner}"),
         ]
     else:
-        content = "Owner: Unowned"
+        content = ["Owner: Unowned"]
 
     return html.H6(children=content, id="model-data-owner")

--- a/amora/dash/components/model_details.py
+++ b/amora/dash/components/model_details.py
@@ -8,6 +8,7 @@ from amora.dash.components import (
     materialization_type_badge,
     model_code,
     model_columns,
+    model_data_owner,
     model_datatable,
     model_summary,
 )
@@ -19,7 +20,10 @@ def component(model: Model) -> Component:
     return dbc.Card(
         [
             dbc.CardHeader(
-                html.H4(model.unique_name(), className="card-title"),
+                children=[
+                    html.H4(model.unique_name(), className="card-title"),
+                    model_data_owner.layout(model),
+                ]
             ),
             dbc.CardBody(
                 [

--- a/amora/dash/pages/owners.py
+++ b/amora/dash/pages/owners.py
@@ -36,7 +36,7 @@ def list_models_owned_by(owner: str) -> Component:
     )
 
 
-def list_model_owners() -> Component:
+def model_owners_list() -> Component:
     return dbc.ListGroup(
         children=[
             dbc.ListGroupItem(
@@ -57,7 +57,6 @@ def list_model_owners() -> Component:
                 )
             )
             for owner, owned_models in owners_to_models_dict().items()
-            if owner
         ]
     )
 
@@ -66,11 +65,16 @@ def layout(owner: str = None) -> Component:
     if owner:
         owner = urllib.parse.unquote(owner)
         content = [
-            dbc.Row(html.H4(owner)),
-            dbc.Row(html.P("List of owned Data Models:")),
-            dbc.Row(list_models_owned_by(owner)),
+            html.H1("Data Owners"),
+            html.H4(owner),
+            html.P("List of owned Data Models:"),
+            list_models_owned_by(owner),
         ]
     else:
-        content = dbc.Row(list_model_owners())
+        content = [
+            html.H1("Data Owners"),
+            html.P("List of Data Owners and the associated Data Models:"),
+            model_owners_list(),
+        ]
 
-    return dbc.Container(children=content)
+    return dbc.Container(children=[dbc.Row(row) for row in content])

--- a/amora/dash/pages/owners.py
+++ b/amora/dash/pages/owners.py
@@ -1,0 +1,76 @@
+import urllib.parse
+
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+from dash import html
+from dash.development.base_component import Component
+
+from amora.models import list_models_with_owner, owners_to_models_dict
+
+dash.register_page(
+    __name__,
+    name="Data Owners",
+    path_template="/owners/<owner>",
+    path="/owners",
+)
+
+
+def list_models_owned_by(owner: str) -> Component:
+    models = list(list_models_with_owner(owner=owner))
+    if not models:
+        return html.Div(f"There are no models owned by `{owner}`")
+
+    return dbc.ListGroup(
+        children=[
+            dbc.ListGroupItem(
+                children=[
+                    dcc.Link(
+                        model.unique_name(), href=f"/models/{model.unique_name()}"
+                    ),
+                    html.P(model.__model_config__.description),
+                ]
+            )
+            for model, _file_path in models
+        ]
+    )
+
+
+def list_model_owners() -> Component:
+    return dbc.ListGroup(
+        children=[
+            dbc.ListGroupItem(
+                dbc.Row(
+                    children=[
+                        dbc.Col(dcc.Link(owner, href=f"/owners/{owner}"), width=11),
+                        dbc.Col(
+                            dbc.Badge(
+                                len(owned_models),
+                                title=f"Owns {len(owned_models)} models",
+                                color="primary",
+                                className="me-1",
+                            ),
+                            width=1,
+                        ),
+                    ],
+                    justify="between",
+                )
+            )
+            for owner, owned_models in owners_to_models_dict().items()
+            if owner
+        ]
+    )
+
+
+def layout(owner: str = None) -> Component:
+    if owner:
+        owner = urllib.parse.unquote(owner)
+        content = [
+            dbc.Row(html.H4(owner)),
+            dbc.Row(html.P("List of owned Data Models:")),
+            dbc.Row(list_models_owned_by(owner)),
+        ]
+    else:
+        content = dbc.Row(list_model_owners())
+
+    return dbc.Container(children=content)

--- a/amora/models.py
+++ b/amora/models.py
@@ -304,10 +304,12 @@ def list_models_with_owner(owner: Union[str, Owner]) -> Iterable[Tuple[Model, Pa
             yield model, file_path
 
 
-def owners_to_models_dict() -> Dict[Union[Owner, None], List[Model]]:
+def owners_to_models_dict() -> Dict[str, List[Model]]:
     owners_dict = defaultdict(list)
     for model, _ in list_models():
-        owners_dict[model.owner()].append(model)
+        owner = model.owner()
+        if owner:
+            owners_dict[owner].append(model)
     return owners_dict
 
 

--- a/amora/models.py
+++ b/amora/models.py
@@ -105,6 +105,9 @@ class MaterializationTypes(AutoName):
     table = auto()
 
 
+Owner = NameEmail
+
+
 @dataclasses.dataclass
 class ModelConfig:
     """
@@ -123,7 +126,7 @@ class ModelConfig:
     partition_by: Optional[PartitionConfig] = None
     cluster_by: Optional[List[str]] = None
     labels: Labels = dataclasses.field(default_factory=set)
-    owner: Optional[NameEmail] = None
+    owner: Optional[Owner] = None
 
     @property
     def labels_dict(self) -> Dict[str, str]:
@@ -289,6 +292,15 @@ def list_models(
                 extra={"model_file_path": model_file_path},
             )
             continue
+
+
+def list_models_with_owner(owner: Union[str, Owner]) -> Iterable[Tuple[Model, Path]]:
+    if isinstance(owner, str):
+        owner = Owner.validate(owner)
+
+    for model, file_path in list_models():
+        if owner == model.__model_config__.owner:
+            yield model, file_path
 
 
 def select_models_with_labels(labels: Labels) -> Iterable[Tuple[Model, Path]]:

--- a/amora/models.py
+++ b/amora/models.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 import inspect
 import re
+from collections import defaultdict
 from enum import Enum, auto
 from inspect import getfile
 from pathlib import Path
@@ -301,6 +302,13 @@ def list_models_with_owner(owner: Union[str, Owner]) -> Iterable[Tuple[Model, Pa
     for model, file_path in list_models():
         if owner == model.__model_config__.owner:
             yield model, file_path
+
+
+def owners_to_models_dict() -> Dict[Union[Owner, None], List[Model]]:
+    owners_dict = defaultdict(list)
+    for model, _ in list_models():
+        owners_dict[model.owner()].append(model)
+    return owners_dict
 
 
 def select_models_with_labels(labels: Labels) -> Iterable[Tuple[Model, Path]]:

--- a/examples/amora_project/models/health.py
+++ b/examples/amora_project/models/health.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String
 
 from amora.models import AmoraModel, Field, MaterializationTypes, ModelConfig
@@ -9,6 +10,9 @@ class Health(AmoraModel):
     __model_config__ = ModelConfig(
         materialized=MaterializationTypes.table,
         description="Health data exported by the Apple Health App",
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
     )
 
     id: int = Field(Integer, primary_key=True, doc="Identificador único da medida")

--- a/examples/amora_project/models/heart_agg.py
+++ b/examples/amora_project/models/heart_agg.py
@@ -1,3 +1,4 @@
+from pydantic import NameEmail
 from sqlalchemy import Float, Integer, func, select
 
 from amora.models import AmoraModel, Field, MaterializationTypes, ModelConfig
@@ -8,7 +9,12 @@ from examples.amora_project.models.heart_rate import HeartRate
 class HeartRateAgg(AmoraModel):
     __depends_on__ = [HeartRate]
     __tablename__override__ = "heart_rate_agg"
-    __model_config__ = ModelConfig(materialized=MaterializationTypes.table)
+    __model_config__ = ModelConfig(
+        materialized=MaterializationTypes.table,
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
+    )
 
     avg: float = Field(Float)
     sum: float = Field(Float)

--- a/examples/amora_project/models/heart_rate.py
+++ b/examples/amora_project/models/heart_rate.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
 from amora.models import (
@@ -24,6 +25,10 @@ class HeartRate(AmoraModel):
         ),
         cluster_by=["sourceName"],
         labels={Label("freshness", "daily")},
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
+        description="Heart Rate measurement events",
     )
 
     id: int = Field(Integer, primary_key=True, doc="Identificador único da medida")

--- a/examples/amora_project/models/heart_rate_over_100.py
+++ b/examples/amora_project/models/heart_rate_over_100.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
+from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
 from amora.models import AmoraModel, Field, Label, MaterializationTypes, ModelConfig
@@ -14,6 +15,9 @@ class HeartRateOver100(AmoraModel):
     __model_config__ = ModelConfig(
         materialized=MaterializationTypes.view,
         labels={Label("freshness", "daily")},
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
     )
 
     unit: str = Field(String, doc="Unidade de medida")

--- a/examples/amora_project/models/step_count_by_source.py
+++ b/examples/amora_project/models/step_count_by_source.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 import humanize
+from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, func, literal, select
 
 from amora.feature_store.decorators import feature_view
@@ -23,6 +24,10 @@ class StepCountBySource(AmoraModel):
             Label("upstream", "apple_health"),
             Label("domain", "health"),
         },
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
+        description="Step count measurements aggregated by hour",
     )
 
     value_avg: float = Field(Float, doc="Average step count of the hour")

--- a/examples/amora_project/models/steps.py
+++ b/examples/amora_project/models/steps.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
 from amora.models import (
@@ -25,6 +26,9 @@ class Steps(AmoraModel):
         labels={Label("freshness", "daily")},
         description="Health automatically counts your steps, walking, and "
         "running distances. This table stores step measurement events",
+        owner=NameEmail(
+            name="Diogo Magalhães Machado", email="diogo.martins@stone.com.br"
+        ),
     )
 
     id: int = Field(Integer, primary_key=True, doc="Identificador único da medida")


### PR DESCRIPTION
- ✨ feat(models): Adds `amora.models.list_models_with_owner`
- ✨ feat(models): Adds `amora.models.owners_to_models_dict`
- ✨ feat(dash): Adds `/owners` page
- ✨ feat(dash): Adds "Data Owner" to the `amora.dash.components.model_details`
- ✨ feat(examples): Adds Data Owners to example models

## Model details with an owner
<img width="964" alt="Screen Shot 2022-11-10 at 22 23 35" src="https://user-images.githubusercontent.com/6271498/201240430-553dd8a8-2834-433c-8012-f4113132529a.png">

## Ownerless model

<img width="982" alt="Screen Shot 2022-11-10 at 22 26 42" src="https://user-images.githubusercontent.com/6271498/201240820-202fdc56-ee7d-44bc-a1e6-81af4410e5d8.png">


## `/owners/`

<img width="966" alt="Screen Shot 2022-11-10 at 22 25 07" src="https://user-images.githubusercontent.com/6271498/201240623-4662db35-1ab1-4caf-8832-a3985130c4b9.png">


## `/owners/<owner>`
<img width="1037" alt="Screen Shot 2022-11-10 at 22 24 19" src="https://user-images.githubusercontent.com/6271498/201240506-1db6113b-a6fa-4b78-92fa-67f5829ecc6d.png">
