### PR TITLE
Create/expiration table

### DIFF
--- a/amora/cli/models.py
+++ b/amora/cli/models.py
@@ -12,15 +12,12 @@ from shed import shed
 
 from amora.config import settings
 from amora.models import Model, list_models
-from amora.providers.bigquery import (
-    BIGQUERY_TYPES_TO_PYTHON_TYPES,
-    BIGQUERY_TYPES_TO_SQLALCHEMY_TYPES,
-    DryRunResult,
-    dry_run,
-    estimated_query_cost_in_usd,
-    estimated_storage_cost_in_usd,
-    get_schema,
-)
+from amora.providers.bigquery import (BIGQUERY_TYPES_TO_PYTHON_TYPES,
+                                      BIGQUERY_TYPES_TO_SQLALCHEMY_TYPES,
+                                      DryRunResult, dry_run,
+                                      estimated_query_cost_in_usd,
+                                      estimated_storage_cost_in_usd,
+                                      get_schema)
 
 app = typer.Typer(help="List or import Amora Models")
 

--- a/amora/dash/components/model_details.py
+++ b/amora/dash/components/model_details.py
@@ -3,15 +3,9 @@ from dash import html
 from dash.development.base_component import Component
 
 from amora.dag import DependencyDAG
-from amora.dash.components import (
-    dependency_dag,
-    materialization_type_badge,
-    model_code,
-    model_columns,
-    model_data_owner,
-    model_datatable,
-    model_summary,
-)
+from amora.dash.components import (dependency_dag, materialization_type_badge,
+                                   model_code, model_columns, model_data_owner,
+                                   model_datatable, model_summary)
 from amora.models import Model
 
 

--- a/amora/dash/components/question_details.py
+++ b/amora/dash/components/question_details.py
@@ -5,7 +5,8 @@ from dash.development.base_component import Component
 
 from amora.logger import logger
 from amora.questions import Question
-from amora.visualization import BarChart, BigNumber, Heatmap, LineChart, PieChart
+from amora.visualization import (BarChart, BigNumber, Heatmap, LineChart,
+                                 PieChart)
 
 
 def answer_visualization(question: Question) -> Component:

--- a/amora/dash/pages/feature_store.py
+++ b/amora/dash/pages/feature_store.py
@@ -6,13 +6,9 @@ from dash import html
 from dash.development.base_component import Component
 from feast import Feature, FeatureView
 
-from amora.dash.components import (
-    materialization_badge,
-    model_columns,
-    model_datatable,
-    model_labels,
-    model_summary,
-)
+from amora.dash.components import (materialization_badge, model_columns,
+                                   model_datatable, model_labels,
+                                   model_summary)
 from amora.feature_store import fs as store
 from amora.feature_store.registry import FEATURE_REGISTRY
 from amora.models import Model

--- a/amora/materialization.py
+++ b/amora/materialization.py
@@ -4,22 +4,11 @@ from pathlib import Path
 from typing import Optional
 
 import humanize
-from google.cloud.bigquery import (
-    Client,
-    PartitionRange,
-    QueryJobConfig,
-    RangePartitioning,
-    Table,
-    TimePartitioning,
-)
+from google.cloud.bigquery import (Client, PartitionRange, QueryJobConfig,
+                                   RangePartitioning, Table, TimePartitioning)
 
-from amora.models import (
-    MaterializationTypes,
-    Model,
-    ModelConfig,
-    amora_model_for_name,
-    amora_model_for_target_path,
-)
+from amora.models import (MaterializationTypes, Model, ModelConfig,
+                          amora_model_for_name, amora_model_for_target_path)
 from amora.providers.bigquery import schema_for_model
 
 
@@ -106,6 +95,9 @@ def materialize(sql: str, model_name: str, config: ModelConfig) -> Optional[Resu
                     field=config.partition_by.field,
                     type_=config.partition_by.granularity.upper(),
                 )
+
+        if config.expiration_table:
+            table.expires = config.expiration_table
 
         client.create_table(table)
 

--- a/amora/meta_queries.py
+++ b/amora/meta_queries.py
@@ -2,18 +2,8 @@ from datetime import date
 
 import pandas as pd
 from numpy import nan
-from sqlalchemy import (
-    ARRAY,
-    Float,
-    Integer,
-    Numeric,
-    String,
-    cast,
-    func,
-    literal,
-    select,
-    union_all,
-)
+from sqlalchemy import (ARRAY, Float, Integer, Numeric, String, cast, func,
+                        literal, select, union_all)
 from sqlalchemy_bigquery import STRUCT
 
 from amora.feature_store.protocols import FeatureViewSourceProtocol

--- a/amora/models.py
+++ b/amora/models.py
@@ -3,22 +3,13 @@ import importlib
 import inspect
 import re
 from collections import defaultdict
+from datetime import datetime
 from enum import Enum, auto
 from inspect import getfile
 from pathlib import Path
 from types import ModuleType
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import (Any, Dict, Iterable, List, NamedTuple, Optional, Set,
+                    Tuple, Type, Union)
 
 from pydantic import NameEmail
 from sqlalchemy import Column, MetaData, Table
@@ -128,6 +119,7 @@ class ModelConfig:
     cluster_by: Optional[List[str]] = None
     labels: Labels = dataclasses.field(default_factory=set)
     owner: Optional[Owner] = None
+    expiration_table: Optional[datetime] = None
 
     @property
     def labels_dict(self) -> Dict[str, str]:

--- a/amora/providers/bigquery.py
+++ b/amora/providers/bigquery.py
@@ -2,38 +2,20 @@ import dataclasses
 import decimal
 from datetime import date, datetime, time
 from enum import Enum
-from typing import Any, Callable, Dict, Hashable, Iterable, List, Optional, Union
+from typing import (Any, Callable, Dict, Hashable, Iterable, List, Optional,
+                    Union)
 
 import pandas as pd
 import sqlalchemy
 from google.api_core.client_info import ClientInfo
 from google.api_core.exceptions import NotFound
-from google.cloud.bigquery import (
-    Client,
-    QueryJobConfig,
-    SchemaField,
-    Table,
-    TableReference,
-)
+from google.cloud.bigquery import (Client, QueryJobConfig, SchemaField, Table,
+                                   TableReference)
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
-from sqlalchemy import (
-    Column,
-    String,
-    func,
-    literal,
-    literal_column,
-    select,
-    tablesample,
-    union_all,
-)
-from sqlalchemy.sql import (
-    ColumnElement,
-    coercions,
-    expression,
-    operators,
-    roles,
-    sqltypes,
-)
+from sqlalchemy import (Column, String, func, literal, literal_column, select,
+                        tablesample, union_all)
+from sqlalchemy.sql import (ColumnElement, coercions, expression, operators,
+                            roles, sqltypes)
 from sqlalchemy.sql.selectable import CTE
 from sqlalchemy.sql.sqltypes import ARRAY
 from sqlalchemy_bigquery import STRUCT
@@ -43,13 +25,8 @@ from amora.compilation import compile_statement
 from amora.config import settings
 from amora.contracts import BaseResult
 from amora.logger import log_execution, logger
-from amora.models import (
-    SQLALCHEMY_METADATA_KEY,
-    AmoraModel,
-    Field,
-    MaterializationTypes,
-    Model,
-)
+from amora.models import (SQLALCHEMY_METADATA_KEY, AmoraModel, Field,
+                          MaterializationTypes, Model)
 from amora.protocols import Compilable
 from amora.storage import cache
 from amora.version import VERSION

--- a/amora/tests/assertions.py
+++ b/amora/tests/assertions.py
@@ -4,14 +4,16 @@ import os
 from typing import Callable, Iterable, Optional
 
 import pytest
-from sqlalchemy import ARRAY, Integer, and_, func, literal, or_, select, union_all
+from sqlalchemy import (ARRAY, Integer, and_, func, literal, or_, select,
+                        union_all)
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import ColumnElement, Select
 
 from amora.config import settings
 from amora.models import AmoraModel
 from amora.protocols import Compilable
-from amora.providers.bigquery import RunResult, estimated_query_cost_in_usd, run
+from amora.providers.bigquery import (RunResult, estimated_query_cost_in_usd,
+                                      run)
 from amora.storage import local_engine
 from amora.tests.audit import AuditLog
 

--- a/amora/tests/generic_tests.py
+++ b/amora/tests/generic_tests.py
@@ -2,11 +2,8 @@
 Tests that can be reused by multiple projects
 """
 from amora.models import MaterializationTypes, list_models
-from amora.providers.bigquery import (
-    get_schema,
-    schema_for_model,
-    schema_for_model_source,
-)
+from amora.providers.bigquery import (get_schema, schema_for_model,
+                                      schema_for_model_source)
 
 
 def test_materialized_schema_equal_local_schema():

--- a/examples/amora_project/dashboards/steps.py
+++ b/examples/amora_project/dashboards/steps.py
@@ -1,12 +1,9 @@
 from amora.dashboards import AcceptedValuesFilter, Dashboard, DateFilter
 from examples.amora_project.models.step_count_by_source import (
-    how_many_data_points_where_acquired,
-    what_are_the_available_data_sources,
+    how_many_data_points_where_acquired, what_are_the_available_data_sources,
     what_are_the_values_observed_on_the_iphone,
     what_is_the_current_estimated_walked_distance,
-    what_is_the_latest_data_point,
-    what_is_the_total_step_count_to_date,
-)
+    what_is_the_latest_data_point, what_is_the_total_step_count_to_date)
 
 dashboard = Dashboard(
     uid="1",

--- a/examples/amora_project/models/heart_rate.py
+++ b/examples/amora_project/models/heart_rate.py
@@ -3,14 +3,8 @@ from datetime import datetime
 from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    MaterializationTypes,
-    ModelConfig,
-    PartitionConfig,
-)
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig, PartitionConfig)
 from amora.protocols import Compilable
 from examples.amora_project.models.health import Health
 

--- a/examples/amora_project/models/heart_rate_over_100.py
+++ b/examples/amora_project/models/heart_rate_over_100.py
@@ -4,7 +4,8 @@ from typing import Optional
 from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import AmoraModel, Field, Label, MaterializationTypes, ModelConfig
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig)
 from amora.protocols import Compilable
 from examples.amora_project.models.heart_rate import HeartRate
 

--- a/examples/amora_project/models/step_count_by_source.py
+++ b/examples/amora_project/models/step_count_by_source.py
@@ -6,7 +6,8 @@ from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, func, literal, select
 
 from amora.feature_store.decorators import feature_view
-from amora.models import AmoraModel, Field, Label, MaterializationTypes, ModelConfig
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig)
 from amora.protocols import Compilable
 from amora.questions import question
 from amora.transformations import datetime_trunc_hour

--- a/examples/amora_project/models/steps.py
+++ b/examples/amora_project/models/steps.py
@@ -3,14 +3,8 @@ from datetime import datetime
 from pydantic import NameEmail
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    MaterializationTypes,
-    ModelConfig,
-    PartitionConfig,
-)
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig, PartitionConfig)
 from amora.protocols import Compilable
 from examples.amora_project.models.health import Health
 

--- a/examples/amora_project/tests/test_health.py
+++ b/examples/amora_project/tests/test_health.py
@@ -1,11 +1,6 @@
-from amora.tests.assertions import (
-    expression_is_true,
-    has_accepted_values,
-    is_non_negative,
-    is_not_null,
-    is_unique,
-    that,
-)
+from amora.tests.assertions import (expression_is_true, has_accepted_values,
+                                    is_non_negative, is_not_null, is_unique,
+                                    that)
 from examples.amora_project.models.health import Health
 
 

--- a/examples/amora_project/tests/test_heart_agg.py
+++ b/examples/amora_project/tests/test_heart_agg.py
@@ -1,10 +1,6 @@
-from amora.tests.assertions import (
-    are_unique_together,
-    expression_is_true,
-    has_at_least_one_not_null_value,
-    is_non_negative,
-    that,
-)
+from amora.tests.assertions import (are_unique_together, expression_is_true,
+                                    has_at_least_one_not_null_value,
+                                    is_non_negative, that)
 from examples.amora_project.models.heart_agg import HeartRateAgg
 
 

--- a/examples/amora_project/tests/test_heart_rate.py
+++ b/examples/amora_project/tests/test_heart_rate.py
@@ -1,10 +1,5 @@
-from amora.tests.assertions import (
-    expression_is_true,
-    has_accepted_values,
-    is_non_negative,
-    relationship,
-    that,
-)
+from amora.tests.assertions import (expression_is_true, has_accepted_values,
+                                    is_non_negative, relationship, that)
 from examples.amora_project.models.health import Health
 from examples.amora_project.models.heart_rate import HeartRate
 

--- a/examples/amora_project/tests/test_steps.py
+++ b/examples/amora_project/tests/test_steps.py
@@ -1,10 +1,5 @@
-from amora.tests.assertions import (
-    expression_is_true,
-    has_accepted_values,
-    is_non_negative,
-    relationship,
-    that,
-)
+from amora.tests.assertions import (expression_is_true, has_accepted_values,
+                                    is_non_negative, relationship, that)
 from examples.amora_project.models.health import Health
 from examples.amora_project.models.steps import Steps
 

--- a/tests/cli/test_materialize.py
+++ b/tests/cli/test_materialize.py
@@ -4,7 +4,6 @@ from typer.testing import CliRunner
 
 from amora.cli import app
 from amora.utils import clean_compiled_files
-
 from tests.models.heart_rate import HeartRate
 from tests.models.step_count_by_source import StepCountBySource
 from tests.models.steps import Steps

--- a/tests/dash/pages/test_questions.py
+++ b/tests/dash/pages/test_questions.py
@@ -1,6 +1,7 @@
 from dash.testing.composite import DashComposite
 
-from tests.models.step_count_by_source import how_many_data_points_where_acquired
+from tests.models.step_count_by_source import \
+    how_many_data_points_where_acquired
 
 
 def test_data_questions_page(amora_dash: DashComposite):

--- a/tests/feature_store/test_decorators.py
+++ b/tests/feature_store/test_decorators.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from typing import List
 
 import pytest
-from feast import FeatureView, Field as FeastField, ValueType
+from feast import FeatureView
+from feast import Field as FeastField
+from feast import ValueType
 from feast.types import from_value_type
 from sqlalchemy import ARRAY, DateTime, Float, Integer, String
 

--- a/tests/feature_store/test_registry.py
+++ b/tests/feature_store/test_registry.py
@@ -8,7 +8,6 @@ from amora.feature_store import registry
 from amora.feature_store.decorators import feature_view
 from amora.feature_store.feature_view import name_for_model
 from amora.models import AmoraModel, Field
-
 from tests.models.step_count_by_source import StepCountBySource
 
 

--- a/tests/models/heart_agg.py
+++ b/tests/models/heart_agg.py
@@ -2,7 +2,6 @@ from sqlalchemy import Integer, func, select
 
 from amora.models import AmoraModel, Field
 from amora.protocols import Compilable
-
 from tests.models.heart_rate import HeartRate
 
 

--- a/tests/models/heart_rate.py
+++ b/tests/models/heart_rate.py
@@ -2,16 +2,9 @@ from datetime import datetime
 
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    MaterializationTypes,
-    ModelConfig,
-    PartitionConfig,
-)
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig, PartitionConfig)
 from amora.protocols import Compilable
-
 from tests.models.health import Health
 
 

--- a/tests/models/heart_rate_over_100.py
+++ b/tests/models/heart_rate_over_100.py
@@ -3,7 +3,8 @@ from typing import Optional
 
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import AmoraModel, Field, Label, MaterializationTypes, ModelConfig
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig)
 from amora.protocols import Compilable
 from examples.amora_project.models.heart_rate import HeartRate
 

--- a/tests/models/step_count_by_source.py
+++ b/tests/models/step_count_by_source.py
@@ -4,12 +4,12 @@ from typing import Optional
 from sqlalchemy import TIMESTAMP, Float, Integer, String, func, select
 
 from amora.feature_store.decorators import feature_view
-from amora.models import AmoraModel, Field, Label, MaterializationTypes, ModelConfig
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig)
 from amora.protocols import Compilable
 from amora.questions import question
 from amora.transformations import datetime_trunc_hour
 from amora.visualization import BigNumber
-
 from tests.models.steps import Steps
 
 

--- a/tests/models/steps.py
+++ b/tests/models/steps.py
@@ -2,16 +2,9 @@ from datetime import datetime
 
 from sqlalchemy import TIMESTAMP, Float, Integer, String, select
 
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    MaterializationTypes,
-    ModelConfig,
-    PartitionConfig,
-)
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig, PartitionConfig)
 from amora.protocols import Compilable
-
 from tests.models.health import Health
 
 

--- a/tests/providers/test_bigquery.py
+++ b/tests/providers/test_bigquery.py
@@ -7,18 +7,8 @@ import pandas as pd
 import pytest
 from google.api_core.exceptions import NotFound
 from google.cloud.bigquery.schema import SchemaField
-from sqlalchemy import (
-    ARRAY,
-    TIMESTAMP,
-    Boolean,
-    Date,
-    DateTime,
-    Float,
-    Integer,
-    String,
-    Time,
-    select,
-)
+from sqlalchemy import (ARRAY, TIMESTAMP, Boolean, Date, DateTime, Float,
+                        Integer, String, Time, select)
 from sqlalchemy.exc import CompileError
 from sqlalchemy.sql.selectable import CTE
 from sqlalchemy_bigquery import STRUCT
@@ -26,32 +16,18 @@ from sqlalchemy_bigquery.base import BQArray
 
 from amora.compilation import compile_statement
 from amora.config import settings
-from amora.models import (
-    SQLALCHEMY_METADATA_KEY,
-    AmoraModel,
-    Field,
-    MaterializationTypes,
-    ModelConfig,
-)
+from amora.models import (SQLALCHEMY_METADATA_KEY, AmoraModel, Field,
+                          MaterializationTypes, ModelConfig)
 from amora.protocols import Compilable
-from amora.providers.bigquery import (
-    DryRunResult,
-    array,
-    column_for_schema_field,
-    cte_from_dataframe,
-    cte_from_rows,
-    dry_run,
-    estimated_query_cost_in_usd,
-    estimated_storage_cost_in_usd,
-    get_fully_qualified_id,
-    run,
-    sample,
-    schema_for_model,
-    schema_for_model_source,
-    struct_for_model,
-    zip_arrays,
-)
-
+from amora.providers.bigquery import (DryRunResult, array,
+                                      column_for_schema_field,
+                                      cte_from_dataframe, cte_from_rows,
+                                      dry_run, estimated_query_cost_in_usd,
+                                      estimated_storage_cost_in_usd,
+                                      get_fully_qualified_id, run, sample,
+                                      schema_for_model,
+                                      schema_for_model_source,
+                                      struct_for_model, zip_arrays)
 from tests.models.health import Health
 from tests.models.heart_rate import HeartRate
 from tests.models.heart_rate_over_100 import HeartRateOver100

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,20 +1,13 @@
 from sqlalchemy import func, literal
 
 from amora.providers.bigquery import array, cte_from_rows
-from amora.tests.assertions import (
-    are_unique_together,
-    expression_is_true,
-    has_accepted_values,
-    has_at_least_one_not_null_value,
-    has_the_same_array_length,
-    is_a_non_empty_string,
-    is_non_negative,
-    is_not_null,
-    is_numeric,
-    is_unique,
-    relationship,
-    that,
-)
+from amora.tests.assertions import (are_unique_together, expression_is_true,
+                                    has_accepted_values,
+                                    has_at_least_one_not_null_value,
+                                    has_the_same_array_length,
+                                    is_a_non_empty_string, is_non_negative,
+                                    is_not_null, is_numeric, is_unique,
+                                    relationship, that)
 
 
 def test_is_numeric_with_numeric_column():

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -8,8 +8,8 @@ from sqlalchemy_bigquery.base import BQArray
 from amora.compilation import compile_statement
 from amora.models import AmoraModel, amora_model_for_path
 from amora.providers.bigquery import fixed_unnest
-
-from tests.models.deeply.nested.array_repeated_fields import ArrayRepeatedFields
+from tests.models.deeply.nested.array_repeated_fields import \
+    ArrayRepeatedFields
 
 
 def test_amora_model_for_path_with_invalid_file_path_type():

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,6 +1,5 @@
 from amora.dag import DependencyDAG
 from amora.utils import clean_compiled_files
-
 from tests.models.health import Health
 from tests.models.heart_agg import HeartRateAgg
 from tests.models.heart_rate import HeartRate

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -10,7 +10,6 @@ from _hashlib import HASH
 from amora.config import settings
 from amora.manifest import Manifest, ModelMetadata, hash_file
 from amora.models import amora_model_for_path
-
 from tests.models.health import Health
 from tests.models.step_count_by_source import StepCountBySource
 from tests.models.steps import Steps

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -9,17 +9,10 @@ from sqlalchemy import TIMESTAMP, DateTime, Integer
 from amora.config import settings
 from amora.dag import DependencyDAG
 from amora.materialization import Task, materialize
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    MaterializationTypes,
-    ModelConfig,
-    PartitionConfig,
-)
+from amora.models import (AmoraModel, Field, Label, MaterializationTypes,
+                          ModelConfig, PartitionConfig)
 from amora.providers.bigquery import schema_for_model
 from amora.utils import clean_compiled_files
-
 from tests.models.heart_agg import HeartRateAgg
 from tests.models.heart_rate import HeartRate
 from tests.models.steps import Steps

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,20 +3,14 @@ from pathlib import Path
 import pytest
 
 from amora.compilation import compile_statement
-from amora.models import (
-    AmoraModel,
-    Field,
-    Label,
-    ModelConfig,
-    amora_model_for_name,
-    amora_model_for_path,
-    amora_model_for_target_path,
-    amora_model_from_name_list,
-    select_models_with_label_keys,
-    select_models_with_labels,
-)
-
-from tests.models.deeply.nested.array_repeated_fields import ArrayRepeatedFields
+from amora.models import (AmoraModel, Field, Label, ModelConfig,
+                          amora_model_for_name, amora_model_for_path,
+                          amora_model_for_target_path,
+                          amora_model_from_name_list,
+                          select_models_with_label_keys,
+                          select_models_with_labels)
+from tests.models.deeply.nested.array_repeated_fields import \
+    ArrayRepeatedFields
 from tests.models.health import Health
 from tests.models.step_count_by_source import StepCountBySource
 from tests.models.steps import Steps

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -2,11 +2,8 @@ from sqlalchemy import select
 
 from amora.providers.bigquery import cte_from_rows, run
 from amora.tests.assertions import is_numeric, that
-from amora.transformations import (
-    parse_numbers,
-    remove_leading_zeros,
-    remove_non_numbers,
-)
+from amora.transformations import (parse_numbers, remove_leading_zeros,
+                                   remove_non_numbers)
 
 
 def test_remove_non_numbers():


### PR DESCRIPTION
Não precisamos ter algumas tabelas materializadas para sempre no bigquery. Para evitar isso, é necessário definir um tempo de expiração para essas mesmas tabelas, evitando o trabalho de ter que excluir manualmente. 


materialização da tabela `pagarme_variability` após a materialização com o campo de expiration_table. 
![image](https://user-images.githubusercontent.com/56757180/215926403-b750efcf-442c-4c60-925d-bb032dd47d2d.png)



- [ ] tests 