### PR TITLE
Removes `AMORA_FEATURE_STORE_REPO_PATH` configuration

### DIFF
--- a/amora/feature_store/__init__.py
+++ b/amora/feature_store/__init__.py
@@ -24,7 +24,6 @@ repo_config = RepoConfig(
         "type": settings.OFFLINE_STORE_TYPE,
         **settings.OFFLINE_STORE_CONFIG,
     },
-    repo_path=settings.REPO_PATH,
     entity_key_serialization_version=2,
 )
 

--- a/amora/feature_store/config.py
+++ b/amora/feature_store/config.py
@@ -29,7 +29,6 @@ class FeatureStoreSettings(BaseSettings):
     REGISTRY: str = NamedTemporaryFile(
         suffix="amora-feature-store-registry", delete=False
     ).name
-    REPO_PATH: str = NamedTemporaryFile(suffix="repo-path", delete=False).name
     PROVIDER: str = FeatureStoreProviders.local.value
     OFFLINE_STORE_TYPE: str = FeatureStoreOfflineStoreTypes.file.value
     OFFLINE_STORE_CONFIG: Dict[str, str] = {}


### PR DESCRIPTION
- 🐛 fix(feature-store): Removes `AMORA_FEATURE_STORE_REPO_PATH` configuration. `repo_path` [is optional](https://github.com/feast-dev/feast/blob/v0.29-branch/sdk/python/feast/repo_config.py#L152) and unused in amora 