### PR TITLE
fix: Melhora tipagem em amora/feature_store/decorators.py

### DIFF
--- a/amora/feature_store/decorators.py
+++ b/amora/feature_store/decorators.py
@@ -1,11 +1,15 @@
+from typing import TypeVar
+
 from feast import FeatureService
 
 from amora.feature_store.feature_view import feature_view_for_model
 from amora.feature_store.registry import FEATURE_REGISTRY
 from amora.models import Model
 
+AnyModel = TypeVar("AnyModel", bound=Model)
 
-def feature_view(model: Model) -> Model:
+
+def feature_view(model: AnyModel) -> AnyModel:
     """
     Generates a Feature View and a Feature Service for the decorated model.
     Models decorated with `@feature_view` must implement the `FeatureViewSourceProtocol`


### PR DESCRIPTION
Esse PR é apenas uma pequena melhoria para ajudar no _auto-complete_ de editores.

Conceitualmente, ainda há um trabalho maior a ser feito, porque de dentro do contexto `amora/feature_store` existe uma quebra de fronteiras (pensanddo nos tipos necessários para se trabalhar)